### PR TITLE
add custom allocator to tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,6 +1290,9 @@ At a minimum, the adapter must provide two static member functions:
 - **operator delete(void*, size_t)** – deallocates memory
 
 If operator new is marked `noexcept`, you must also define a static function named `get_return_object_on_allocation_failure()` to handle allocation failures.
+
+Note: *Even if you do not define `operator new` as `noexcept`, you still need to provide at least one template parameter to the adapter. This parameter will be instantiated with the actual promise type by the coroutine frame and can be use if needed.*
+
 A simple example using std::malloc and std::free would look like this:
 ```cpp
 template<typename PromiseT>

--- a/README.md
+++ b/README.md
@@ -1217,7 +1217,7 @@ UnbufferedChannel(std::function<void(ValueT&)> cleanupFunc = {});
   Returns whether the channel is open.
 
 
-### Exmaple:
+### Example:
 
 ```cpp
 #include <tinycoro/UnbufferedChannel.hpp>
@@ -1268,87 +1268,141 @@ The operations on `BufferedChannel` and `UnbufferedChannel` returns an `EChannel
 - `LAST`: Indicates the last value was received, and the channel is now closed.
 - `CLOSED`: The operation failed because the channel was already closed.
 
-## Allocators
+## `Allocators`
 
-Tinycoro supports custom allocators, which are used to control memory allocation for coroutine frames. This feature is enabled by specifying an allocator adapter as a template parameter in the Task or InlineTask type. For example:
+Tinycoro supports **custom allocators** for controlling memory allocation of coroutine frames. This is achieved by specifying an **allocator adapter** as a template argument in the `Task` or `InlineTask` types. For example:
+
 ```cpp
 tinycoro::Task<void, CustomAllocatorAdapter>
 tinycoro::InlineTask<int32_t, CustomAllocatorAdapter>
 ```
 
-Here’s a simple coroutine that uses a custom allocator adapter:
+Here’s a simple coroutine using a custom allocator adapter:
+
 ```cpp
 tinycoro::Task<int32_t, AllocAdapter> Coroutine() {
     co_return 42;
 }
 ```
 
+---
+
 ### `AllocatorAdapter`
-An allocator adapter is a template that defines how memory is allocated and deallocated for coroutine promises. It is passed as a template argument to Task or InlineTask.
-At a minimum, the adapter must provide two static member functions:
-- **operator new(size_t)** – allocates memory
-- **operator delete(void*, size_t)** – deallocates memory
 
-If operator new is marked `noexcept`, you must also define a static function named `get_return_object_on_allocation_failure()` to handle allocation failures.
+An **allocator adapter** is a class template that defines how memory is allocated and deallocated for the coroutine’s promise type included coroutine frame. It is passed as a **single template argument** to `Task` or `InlineTask`, and must accept exactly **one template parameter**, which is the promise type.
 
-Note: *Even if you do not define `operator new` as `noexcept`, you still need to provide at least one template parameter to the adapter. This parameter will be instantiated with the actual promise type by the coroutine frame and can be use if needed.*
+The adapter must define (at minimum) these two static functions:
 
-A simple example using std::malloc and std::free would look like this:
+- `operator new(size_t)` – allocates memory  
+- `operator delete(void*, size_t)` – deallocates memory
+
+If `operator new` is marked `noexcept`, the adapter must also define:
+
+- `get_return_object_on_allocation_failure()` – to handle allocation failure gracefully.
+
+> ⚠️ **Important:** The allocator adapter must be a class template with exactly **one** template parameter.  
+> If your adapter depends on additional types (e.g., a custom allocator), you must wrap it using an alias template.  
+> For example:
+> ```cpp
+> template<typename T>
+> using Adapter = MyAdapter<T, CustomAllocatorType>;
+> ```
+
+> 💡 **Note:** This design implicitly encourages the use of **global** or **static** allocator instances.  
+> This avoids dangling references or lifetime issues that can occur when coroutine frames outlive their local allocator context.  
+> While this may seem restrictive, it provides a **safer** and more **predictable** memory model for asynchronous code.
+
+A minimal example using `std::malloc` and `std::free`:
+
 ```cpp
 template<typename PromiseT>
-        struct ExampleAllocatorAdapter
-        {
-            // ensure the use of non-throwing operator-new
-            [[noreturn]] static std::coroutine_handle<PromiseT> get_return_object_on_allocation_failure()
-            {
-                throw std::bad_alloc{};
-            }
+struct MallocFreeAdapter
+{
+    [[noreturn]] static std::coroutine_handle<PromiseT> get_return_object_on_allocation_failure()
+    {
+        throw std::bad_alloc{};
+    }
 
-            // operator new noexcept
-            [[nodiscard]] static void* operator new(size_t nbytes) noexcept
-            {
-                return std::malloc(nbytes);
-            }
+    [[nodiscard]] static void* operator new(size_t nbytes) noexcept
+    {
+        return std::malloc(nbytes);
+    }
 
-            // operator delete
-            static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept
-            {
-                std::free(ptr);
-            }
-        };
-
+    static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept
+    {
+        std::free(ptr);
+    }
+};
 ```
+
+**Usage:**
+
+```cpp
+tinycoro::Task<int32_t, MallocFreeAdapter> Coroutine(int32_t val)
+{
+    co_return val;
+}
+```
+
+---
 
 ### `Allocator`
-If you need more control over memory management (e.g., using a fixed-size buffer or pooling), you can define your own allocator class and a corresponding adapter.
+
+For more advanced use cases (e.g., memory pooling or pre-allocated buffers), you can implement your own allocator class and plug it into a reusable adapter.
+
 ```cpp
+// Adapter taking both Promise and custom allocator.
 template <typename PromiseT, typename AllocatorT>
-    struct AllocatorAdapter
+struct AllocatorAdapter
+{
+    [[nodiscard]] static void* operator new(size_t nbytes)
     {
-        [[nodiscard]] static void* operator new(size_t nbytes) { return AllocatorT::s_allocator.allocate_bytes(nbytes); }
+        return AllocatorT::s_allocator.allocate_bytes(nbytes);
+    }
 
-        static void operator delete(void* ptr, size_t nbytes) noexcept { AllocatorT::s_allocator.deallocate_bytes(ptr, nbytes); }
-    };
-
-    template <typename OwnerT, std::unsigned_integral auto SIZE>
-    struct Allocator
+    static void operator delete(void* ptr, size_t nbytes) noexcept
     {
-        template<typename T>
-        using adapter_t = AllocatorAdapter<T, Allocator>;
-
-        template<typename, typename>
-        friend struct AllocatorAdapter;
-
-        void release() noexcept { s_spr.release(); }
-
-    private:
-        static inline std::unique_ptr<std::byte[]>               s_buffer = std::make_unique<std::byte[]>(SIZE);
-        static inline std::pmr::monotonic_buffer_resource        s_mbr{s_buffer.get(), SIZE};
-        static inline std::pmr::synchronized_pool_resource       s_spr{&s_mbr};
-        static inline std::pmr::polymorphic_allocator<std::byte> s_allocator{&s_spr};
-    };
-
+        AllocatorT::s_allocator.deallocate_bytes(ptr, nbytes);
+    }
+};
 ```
+
+Define a custom allocator and expose a usable adapter:
+
+```cpp
+template <std::unsigned_integral auto SIZE>
+struct Allocator
+{
+    // This alias produces a single-parameter adapter.
+    template<typename T>
+    using adapter_t = AllocatorAdapter<T, Allocator>;
+
+    // Adapter is a friend class,
+    // so it has access to private stuffs...
+    template<typename, typename>
+    friend struct AllocatorAdapter;
+
+private:
+    static inline std::unique_ptr<std::byte[]>               s_buffer = std::make_unique<std::byte[]>(SIZE);
+    static inline std::pmr::monotonic_buffer_resource        s_mbr{s_buffer.get(), SIZE};
+    static inline std::pmr::synchronized_pool_resource       s_spr{&s_mbr};
+    static inline std::pmr::polymorphic_allocator<std::byte> s_allocator{&s_spr};
+};
+```
+
+**Usage:**
+
+```cpp
+// Create allocator with 10000 bytes
+using AllocatorT = Allocator<10000>;
+
+// Pass the adapter alias to the task
+tinycoro::Task<void, AllocatorT::adapter_t> Coroutine()
+{
+    co_return;
+}
+```
+
 This setup allows you to fine-tune memory usage for performance or deterministic behavior—especially useful in embedded, real-time, or resource-constrained environments.
 
 ## Warning

--- a/include/tinycoro/AllocatorAdapter.hpp
+++ b/include/tinycoro/AllocatorAdapter.hpp
@@ -1,0 +1,50 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024 Tamas Kovacs
+//  Licensed under the MIT License – see LICENSE.txt for details.
+// -----------------------------------------------------------------------------
+
+#ifndef TINY_CORO_ALLOCATOR_ADAPTER_HPP
+#define TINY_CORO_ALLOCATOR_ADAPTER_HPP
+
+#include <coroutine>
+
+namespace tinycoro
+{
+    namespace detail
+    {
+        // Empty allocator.
+        // It uses the buildin allocation
+        // functionality from the compiler.
+        template<typename PromiseT>
+        struct NonAllocatorAdapter
+        {
+        };
+
+        // This is an example implementation,
+        // not used in the code.
+        template<typename PromiseT>
+        struct ExampleAllocatorAdapter
+        {
+            // ensure the use of non-throwing operator-new
+            [[noreturn]] static std::coroutine_handle<PromiseT> get_return_object_on_allocation_failure()
+            {
+                throw std::bad_alloc{};
+            }
+
+            [[nodiscard]] static void* operator new(size_t nbytes) noexcept
+            {
+                return std::malloc(nbytes);
+            }
+
+            static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept
+            {
+                std::free(ptr);
+            }
+        };
+
+    } // namespace detail
+    
+} // namespace tinycoro
+
+
+#endif // TINY_CORO_ALLOCATOR_ADAPTER_HPP

--- a/include/tinycoro/PauseHandler.hpp
+++ b/include/tinycoro/PauseHandler.hpp
@@ -63,27 +63,27 @@ namespace tinycoro {
         {
         }
 
-        void Resume()
+        void Resume() noexcept
         {
             _state.store(0u, std::memory_order::relaxed);
         }
 
         void ResetCallback(concepts::PauseHandlerCb auto pr) { _resumerCallback = std::move(pr); }
 
-        [[nodiscard]] auto Pause()
+        [[nodiscard]] auto Pause() noexcept
         {
             assert(IsPaused() == false);
             _state.fetch_or(c_pauseMask, std::memory_order_release);
             return _resumerCallback;
         }
 
-        void Unpause()
+        void Unpause() noexcept
         {
             assert(IsPaused());
             _state.fetch_and(~c_pauseMask, std::memory_order_release);
         }
 
-        void SetCancellable(bool flag)
+        void SetCancellable(bool flag) noexcept
         {
             assert(IsCancellable() != flag);
 
@@ -106,7 +106,7 @@ namespace tinycoro {
     };
 
     namespace context {
-        [[nodiscard]] auto PauseTask(auto coroHdl)
+        [[nodiscard]] auto PauseTask(auto coroHdl) noexcept
         {
             auto pauseHandlerPtr = coroHdl.promise().pauseHandler.get();
             assert(pauseHandlerPtr);
@@ -114,7 +114,7 @@ namespace tinycoro {
             return pauseHandlerPtr->Pause();
         }
 
-        void MakeCancellable(auto coroHdl)
+        void MakeCancellable(auto coroHdl) noexcept
         {
             auto pauseHandlerPtr = coroHdl.promise().pauseHandler.get();
             assert(pauseHandlerPtr);
@@ -122,7 +122,7 @@ namespace tinycoro {
             pauseHandlerPtr->SetCancellable(true);
         }
 
-        void UnpauseTask(auto coroHdl)
+        void UnpauseTask(auto coroHdl) noexcept
         {
             auto pauseHandlerPtr = coroHdl.promise().pauseHandler.get();
             assert(pauseHandlerPtr);
@@ -130,7 +130,7 @@ namespace tinycoro {
             pauseHandlerPtr->Unpause();
         }
 
-        [[nodiscard]] auto* GetHandler(auto coroHdl)
+        [[nodiscard]] auto* GetHandler(auto coroHdl) noexcept
         {
             auto pauseHandlerPtr = coroHdl.promise().pauseHandler.get();
             assert(pauseHandlerPtr);

--- a/include/tinycoro/Promise.hpp
+++ b/include/tinycoro/Promise.hpp
@@ -104,9 +104,15 @@ namespace tinycoro {
                 {
                     _value = std::forward<T>(v);
                 }
-                else
+                else if constexpr (requires { _value = value_type{std::forward<T>(v)}; })
                 {
                     _value = value_type{std::forward<T>(v)};
+                }
+                else
+                {
+                    // special case for direct optional assignment
+                    assert(v.has_value());
+                    _value = v.value();
                 }
             }
 

--- a/include/tinycoro/SleepAwaiter.hpp
+++ b/include/tinycoro/SleepAwaiter.hpp
@@ -12,6 +12,7 @@
 #include "Task.hpp"
 #include "CancellableSuspend.hpp"
 #include "AutoEvent.hpp"
+#include "AllocatorAdapter.hpp"
 
 using namespace std::chrono_literals;
 
@@ -32,7 +33,8 @@ namespace tinycoro {
 
     } // namespace concepts
 
-    Task<void> SleepUntil(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint, concepts::IsStopToken auto stopToken)
+    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
+    Task<void, AllocatorAdapterT> SleepUntil(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint, concepts::IsStopToken auto stopToken)
     {
         tinycoro::AutoEvent finished;
 
@@ -48,26 +50,30 @@ namespace tinycoro {
         co_await finished;
     }
 
-    Task<void> SleepFor(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration, concepts::IsStopToken auto stopToken)
+    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
+    Task<void, AllocatorAdapterT> SleepFor(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration, concepts::IsStopToken auto stopToken)
     {
-        co_await SleepUntil(softClock, softClock.Now() + duration, stopToken);
+        co_await SleepUntil<AllocatorAdapterT>(softClock, softClock.Now() + duration, stopToken);
     }
 
-    Task<void> SleepFor(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration)
+    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
+    Task<void, AllocatorAdapterT> SleepFor(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration)
     {
-        auto stopToken = co_await StopTokenAwaiter{};
-        co_await SleepFor(softClock, duration, stopToken);
+        auto stopToken = co_await this_coro::stop_token();
+        co_await SleepFor<AllocatorAdapterT>(softClock, duration, stopToken);
     }
 
-    Task<void> SleepUntil(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint)
+    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
+    Task<void, AllocatorAdapterT> SleepUntil(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint)
     {
-        auto stopToken = co_await StopTokenAwaiter{};
-        co_await SleepUntil(softClock, timePoint, stopToken);
+        auto stopToken = co_await this_coro::stop_token();
+        co_await SleepUntil<AllocatorAdapterT>(softClock, timePoint, stopToken);
     }
     
-    Task<void> SleepUntilCancellable(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint, concepts::IsStopToken auto stopToken)
+    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
+    Task<void, AllocatorAdapterT> SleepUntilCancellable(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint, concepts::IsStopToken auto stopToken)
     {
-        co_await SleepUntil(softClock, timePoint, stopToken);
+        co_await SleepUntil<AllocatorAdapterT>(softClock, timePoint, stopToken);
 
         if (stopToken.stop_requested())
         {
@@ -75,21 +81,24 @@ namespace tinycoro {
         }
     }
 
-    Task<void> SleepForCancellable(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration, concepts::IsStopToken auto stopToken)
+    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
+    Task<void, AllocatorAdapterT> SleepForCancellable(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration, concepts::IsStopToken auto stopToken)
     {
-        co_await SleepUntilCancellable(softClock, softClock.Now() + duration, stopToken);
+        co_await SleepUntilCancellable<AllocatorAdapterT>(softClock, softClock.Now() + duration, stopToken);
     }
 
-    Task<void> SleepForCancellable(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration)
+    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
+    Task<void, AllocatorAdapterT> SleepForCancellable(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration)
     {
-        auto stopToken = co_await StopTokenAwaiter{};
-        co_await SleepForCancellable(softClock, duration, stopToken);
+        auto stopToken = co_await this_coro::stop_token();
+        co_await SleepForCancellable<AllocatorAdapterT>(softClock, duration, stopToken);
     }
 
-    Task<void> SleepUntilCancellable(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint)
+    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
+    Task<void, AllocatorAdapterT> SleepUntilCancellable(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint)
     {
-        auto stopToken = co_await StopTokenAwaiter{};
-        co_await SleepUntilCancellable(softClock, timePoint, stopToken);
+        auto stopToken = co_await this_coro::stop_token();
+        co_await SleepUntilCancellable<AllocatorAdapterT>(softClock, timePoint, stopToken);
     }
 
 } // namespace tinycoro

--- a/include/tinycoro/Task.hpp
+++ b/include/tinycoro/Task.hpp
@@ -150,10 +150,10 @@ namespace tinycoro {
     } // namespace detail
 
     template <typename ReturnValueT = void, template<typename> class AllocatorT = detail::NonAllocatorAdapter>
-    using Task = detail::CoroTask<ReturnValueT, Promise<ReturnValueT, AllocatorT>, AwaiterValue>;
+    using Task = detail::CoroTask<ReturnValueT, detail::Promise<ReturnValueT, AllocatorT>, AwaiterValue>;
 
     template <typename ReturnValueT = void, template<typename> class AllocatorT = detail::NonAllocatorAdapter>
-    using InlineTask = detail::CoroTask<ReturnValueT, InlinePromise<ReturnValueT, AllocatorT>, AwaiterValue>;
+    using InlineTask = detail::CoroTask<ReturnValueT, detail::InlinePromise<ReturnValueT, AllocatorT>, AwaiterValue>;
 
 } // namespace tinycoro
 

--- a/include/tinycoro/Task.hpp
+++ b/include/tinycoro/Task.hpp
@@ -132,7 +132,7 @@ namespace tinycoro {
 
             void destroy() noexcept
             {
-                if (_hdl)
+                if(_hdl)
                 {
                     _hdl.destroy();
                     _hdl = nullptr;
@@ -149,11 +149,11 @@ namespace tinycoro {
 
     } // namespace detail
 
-    template <typename ReturnValueT = void>
-    using Task = detail::CoroTask<ReturnValueT, Promise<ReturnValueT>, AwaiterValue>;
+    template <typename ReturnValueT = void, template<typename> class AllocatorT = detail::NonAllocatorAdapter>
+    using Task = detail::CoroTask<ReturnValueT, Promise<ReturnValueT, AllocatorT>, AwaiterValue>;
 
-    template <typename ReturnValueT = void>
-    using InlineTask = detail::CoroTask<ReturnValueT, InlinePromise<ReturnValueT>, AwaiterValue>;
+    template <typename ReturnValueT = void, template<typename> class AllocatorT = detail::NonAllocatorAdapter>
+    using InlineTask = detail::CoroTask<ReturnValueT, InlinePromise<ReturnValueT, AllocatorT>, AwaiterValue>;
 
 } // namespace tinycoro
 

--- a/test/src/Allocator.hpp
+++ b/test/src/Allocator.hpp
@@ -1,0 +1,36 @@
+#ifndef TINY_CORO_TESTS_ALLOCATOR_HPP
+#define TINY_CORO_TESTS_ALLOCATOR_HPP
+
+#include <memory>
+#include <memory_resource>
+#include <concepts>
+
+namespace tinycoro { namespace test {
+
+    // Allocator to help boosting performance
+    // during unit testing
+    template <typename PromiseT, typename AllocatorT>
+    struct AllocatorAdapter
+    {
+        [[nodiscard]] static void* operator new(size_t nbytes) { return AllocatorT::allocator.allocate_bytes(nbytes); }
+
+        static void operator delete(void* ptr, size_t nbytes) noexcept { AllocatorT::allocator.deallocate_bytes(ptr, nbytes); }
+    };
+
+    template <typename OwnerT, std::unsigned_integral auto SIZE>
+    struct Allocator
+    {
+        template<typename T>
+        using adapter_t = AllocatorAdapter<T, Allocator>;
+
+        static inline std::unique_ptr<std::byte[]>               buffer = std::make_unique<std::byte[]>(SIZE);
+        static inline std::pmr::monotonic_buffer_resource        mbr{buffer.get(), SIZE};
+        static inline std::pmr::synchronized_pool_resource       spr{&mbr};
+        static inline std::pmr::polymorphic_allocator<std::byte> allocator{&spr};
+
+        void release() noexcept { spr.release(); }
+    };
+
+}} // namespace tinycoro::test
+
+#endif // TINY_CORO_TESTS_ALLOCATOR_HPP

--- a/test/src/AllocatorAdapterTest.cpp
+++ b/test/src/AllocatorAdapterTest.cpp
@@ -17,71 +17,65 @@ template <typename PromiseT>
 struct AllocatorAdapterNoExcept
 {
     // ensure the use of non-throwing operator-new
-    [[noreturn]] static std::coroutine_handle<PromiseT> get_return_object_on_allocation_failure() {
+    [[noreturn]] static std::coroutine_handle<PromiseT> get_return_object_on_allocation_failure()
+    {
         g_currentMockPtr->get_return_object_on_allocation_failure();
-        
+
         // as backup always throw
         throw std::bad_alloc{};
     }
 
-    [[nodiscard]] static void* operator new(size_t nbytes) noexcept { 
-        return g_currentMockPtr->allocate_bytes_noexcept(nbytes);
-    }
+    [[nodiscard]] static void* operator new(size_t nbytes) noexcept { return g_currentMockPtr->allocate_bytes_noexcept(nbytes); }
 
-    static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept { 
-        g_currentMockPtr->deallocate_bytes(ptr, nbytes);
-    }
+    static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept { g_currentMockPtr->deallocate_bytes(ptr, nbytes); }
 };
 
 template <typename PromiseT>
 struct AllocatorAdapter
 {
-    [[nodiscard]] static void* operator new(size_t nbytes) { 
-        return g_currentMockPtr->allocate_bytes(nbytes);
-    }
+    [[nodiscard]] static void* operator new(size_t nbytes) { return g_currentMockPtr->allocate_bytes(nbytes); }
 
-    static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept { 
-        g_currentMockPtr->deallocate_bytes(ptr, nbytes);
-    }
+    static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept { g_currentMockPtr->deallocate_bytes(ptr, nbytes); }
 };
 
 struct AllocatorAdapterTest : testing::Test
 {
-    void SetUp() override
-    {
-        g_currentMockPtr = std::addressof(mock);
-    }
+    void SetUp() override { g_currentMockPtr = std::addressof(mock); }
 
-    void TearDown() override
-    {
-        g_currentMockPtr = nullptr;
-    }
+    void TearDown() override { g_currentMockPtr = nullptr; }
 
     MockAllocatorTracer mock;
 };
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_RunInline) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_RunInline)
 {
     EXPECT_CALL(mock, allocate_bytes_noexcept).Times(1).WillOnce([](size_t nbytes) { return std::malloc(nbytes); });
     EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
 
-    auto task = []() -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { int32_t i{}; i++; co_return i; };
+    auto task = []() -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> {
+        int32_t i{};
+        i++;
+        co_return i;
+    };
 
     auto ret = tinycoro::RunInline(task());
     EXPECT_EQ(ret, 1);
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_Async) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_Async)
 {
     tinycoro::Scheduler scheduler;
 
     EXPECT_CALL(mock, allocate_bytes_noexcept).Times(3).WillRepeatedly([](size_t nbytes) { return std::malloc(nbytes); });
     EXPECT_CALL(mock, deallocate_bytes).Times(3).WillRepeatedly([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
 
-    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> {
+        i++;
+        co_return i;
+    };
 
     auto [t1, t2, t3] = tinycoro::GetAll(scheduler, task(0), task(1), task(2));
-    
+
     EXPECT_EQ(t1, 1);
     EXPECT_EQ(t2, 2);
     EXPECT_EQ(t3, 3);
@@ -92,30 +86,39 @@ void bad_alloc(auto& mock, auto task)
     EXPECT_CALL(mock, allocate_bytes_noexcept).Times(1).WillRepeatedly([]([[maybe_unused]] size_t nbytes) { return nullptr; });
     EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
 
-    auto func = [&]{ std::ignore = tinycoro::RunInline(task(0)); }; 
+    auto func = [&] { std::ignore = tinycoro::RunInline(task(0)); };
 
     EXPECT_THROW(func(), std::bad_alloc);
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_bad_alloc) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_bad_alloc)
 {
-    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> {
+        i++;
+        co_return i;
+    };
     bad_alloc(mock, std::move(task));
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_bad_alloc_inlineTask) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_bad_alloc_inlineTask)
 {
-    auto task = [](int32_t i) -> tinycoro::InlineTask<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+    auto task = [](int32_t i) -> tinycoro::InlineTask<int32_t, AllocatorAdapterNoExcept> {
+        i++;
+        co_return i;
+    };
     bad_alloc(mock, std::move(task));
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_bad_alloc_multi) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_bad_alloc_multi)
 {
     EXPECT_CALL(mock, allocate_bytes_noexcept).Times(1).WillRepeatedly([]([[maybe_unused]] size_t nbytes) { return nullptr; });
     EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
 
-    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
-    auto func = [&]{ std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); }; 
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> {
+        i++;
+        co_return i;
+    };
+    auto func = [&] { std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); };
 
     EXPECT_THROW(func(), std::bad_alloc);
 }
@@ -131,25 +134,75 @@ void second_bad_alloc_multi(auto& mock, auto task)
 
     EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
 
-    //auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
-    auto func = [&]{ std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); }; 
+    auto func = [&] { std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); };
 
     EXPECT_THROW(func(), std::bad_alloc);
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi)
 {
-    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> {
+        i++;
+        co_return i;
+    };
     second_bad_alloc_multi(mock, std::move(task));
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi_inline) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi_inline)
 {
-    auto task = [](int32_t i) -> tinycoro::InlineTask<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+    auto task = [](int32_t i) -> tinycoro::InlineTask<int32_t, AllocatorAdapterNoExcept> {
+        i++;
+        co_return i;
+    };
     second_bad_alloc_multi(mock, std::move(task));
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi_async) 
+void third_bad_alloc_multi_syncwait(auto& mock, auto task)
+{
+    EXPECT_CALL(mock, allocate_bytes_noexcept)
+        .Times(3)
+        .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
+        .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { return nullptr; });
+
+    EXPECT_CALL(mock, deallocate_bytes)
+        .Times(2)
+        .WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); })
+        .WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
+
+    EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
+
+    auto func = [&] { tinycoro::RunInline(task()); };
+    EXPECT_THROW(func(), std::bad_alloc);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi_sync_await)
+{
+    tinycoro::Scheduler scheduler;
+
+    auto task = []() -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { co_return 42; };
+
+    auto wrapperTask = [&]() -> tinycoro::Task<void, AllocatorAdapterNoExcept> {
+        std::ignore = co_await tinycoro::SyncAwait(scheduler, task(), task(), task());
+    };
+
+    third_bad_alloc_multi_syncwait(mock, wrapperTask);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi_sync_await_inline)
+{
+    tinycoro::Scheduler scheduler;
+
+    auto task = []() -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { co_return 42; };
+
+    auto wrapperTask = [&]() -> tinycoro::InlineTask<void, AllocatorAdapterNoExcept> {
+        std::ignore = co_await tinycoro::SyncAwait(scheduler, task(), task(), task());
+    };
+
+    third_bad_alloc_multi_syncwait(mock, wrapperTask);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi_async)
 {
     tinycoro::Scheduler scheduler;
 
@@ -162,82 +215,100 @@ TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi_async)
 
     EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
 
-    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
-    auto func = [&]{ std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); }; 
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> {
+        i++;
+        co_return i;
+    };
+    auto func = [&] { std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); };
 
     EXPECT_THROW(func(), std::bad_alloc);
 }
 
-//template<template<typename, template<typename> class> class TaskT>
 void throw_in_operator_new(auto& mock, auto task)
 {
     EXPECT_CALL(mock, allocate_bytes)
         .Times(2)
         .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
-        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { throw std::bad_alloc{}; return nullptr;});
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) {
+            throw std::bad_alloc{};
+            return nullptr;
+        });
 
     EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
 
-    //auto task = [](int32_t i) -> TaskT<int32_t, AllocatorAdapter> { i++; co_return i; };
-    auto func = [&]{ std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); }; 
+    auto func = [&] { std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); };
 
     EXPECT_THROW(func(), std::bad_alloc);
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_throw_in_operator_new) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_throw_in_operator_new)
 {
-    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> { i++; co_return i; };
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> {
+        i++;
+        co_return i;
+    };
+    throw_in_operator_new(mock, task);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_throw_in_operator_new_InlineTask)
+{
+    auto task = [](int32_t i) -> tinycoro::InlineTask<int32_t, AllocatorAdapter> {
+        i++;
+        co_return i;
+    };
     throw_in_operator_new(mock, std::move(task));
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_throw_in_operator_new_InlineTask) 
-{
-    auto task = [](int32_t i) -> tinycoro::InlineTask<int32_t, AllocatorAdapter> { i++; co_return i; };
-    throw_in_operator_new(mock, std::move(task));
-}
-
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_throw_in_operator_new_async) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_throw_in_operator_new_async)
 {
     tinycoro::Scheduler scheduler;
 
     EXPECT_CALL(mock, allocate_bytes)
         .Times(2)
         .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
-        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { throw std::bad_alloc{}; return nullptr; });
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) {
+            throw std::bad_alloc{};
+            return nullptr;
+        });
 
     EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
 
-    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> { i++; co_return i; };
-    auto func = [&]{ std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); }; 
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> {
+        i++;
+        co_return i;
+    };
+    auto func = [&] { std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); };
 
     EXPECT_THROW(func(), std::bad_alloc);
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_sync_await_throw) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_sync_await_throw)
 {
     tinycoro::Scheduler scheduler;
 
     EXPECT_CALL(mock, allocate_bytes)
         .Times(2)
         .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
-        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { throw std::bad_alloc{}; return nullptr; });
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) {
+            throw std::bad_alloc{};
+            return nullptr;
+        });
 
     EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
 
     auto nestedTask = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> { co_return i; };
 
-    auto task = [&](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> { 
-        
+    auto task = [&](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> {
         // this need to throw std::bad_alloc
         std::ignore = co_await tinycoro::SyncAwait(scheduler, nestedTask(0), nestedTask(1));
         co_return ++i;
     };
-    auto func = [&]{ std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); }; 
+    auto func = [&] { std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); };
 
     EXPECT_THROW(func(), std::bad_alloc);
 }
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_sync_await_throw_noexcept) 
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_sync_await_throw_noexcept)
 {
     tinycoro::Scheduler scheduler;
 
@@ -253,13 +324,12 @@ TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_sync_await_throw_noexcept)
 
     auto nestedTask = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { co_return i; };
 
-    auto task = [&](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { 
-        
+    auto task = [&](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> {
         // this need to throw std::bad_alloc
         std::ignore = co_await tinycoro::SyncAwait(scheduler, nestedTask(0), nestedTask(1));
         co_return ++i;
     };
-    auto func = [&]{ std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); }; 
+    auto func = [&] { std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); };
 
     EXPECT_THROW(func(), std::bad_alloc);
 }

--- a/test/src/AllocatorAdapterTest.cpp
+++ b/test/src/AllocatorAdapterTest.cpp
@@ -1,0 +1,229 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <tinycoro/tinycoro_all.h>
+
+struct MockAllocatorTracer
+{
+    MOCK_METHOD(void*, allocate_bytes, (size_t));
+    MOCK_METHOD(void, deallocate_bytes, (void*, size_t), (noexcept));
+    MOCK_METHOD(void*, allocate_bytes_noexcept, (size_t), (noexcept));
+    MOCK_METHOD(void, get_return_object_on_allocation_failure, ());
+};
+
+static MockAllocatorTracer* g_currentMockPtr{nullptr};
+
+template <typename PromiseT>
+struct AllocatorAdapterNoExcept
+{
+    // ensure the use of non-throwing operator-new
+    [[noreturn]] static std::coroutine_handle<PromiseT> get_return_object_on_allocation_failure() {
+        g_currentMockPtr->get_return_object_on_allocation_failure();
+        
+        // as backup always throw
+        throw std::bad_alloc{};
+    }
+
+    [[nodiscard]] static void* operator new(size_t nbytes) noexcept { 
+        return g_currentMockPtr->allocate_bytes_noexcept(nbytes);
+    }
+
+    static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept { 
+        g_currentMockPtr->deallocate_bytes(ptr, nbytes);
+    }
+};
+
+template <typename PromiseT>
+struct AllocatorAdapter
+{
+    [[nodiscard]] static void* operator new(size_t nbytes) { 
+        return g_currentMockPtr->allocate_bytes(nbytes);
+    }
+
+    static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept { 
+        g_currentMockPtr->deallocate_bytes(ptr, nbytes);
+    }
+};
+
+struct AllocatorAdapterTest : testing::Test
+{
+    void SetUp() override
+    {
+        g_currentMockPtr = std::addressof(mock);
+    }
+
+    void TearDown() override
+    {
+        g_currentMockPtr = nullptr;
+    }
+
+    MockAllocatorTracer mock;
+};
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_RunInline) 
+{
+    EXPECT_CALL(mock, allocate_bytes_noexcept).Times(1).WillOnce([](size_t nbytes) { return std::malloc(nbytes); });
+    EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
+
+    auto task = []() -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { int32_t i{}; i++; co_return i; };
+
+    auto ret = tinycoro::RunInline(task());
+    EXPECT_EQ(ret, 1);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_Async) 
+{
+    tinycoro::Scheduler scheduler;
+
+    EXPECT_CALL(mock, allocate_bytes_noexcept).Times(3).WillRepeatedly([](size_t nbytes) { return std::malloc(nbytes); });
+    EXPECT_CALL(mock, deallocate_bytes).Times(3).WillRepeatedly([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
+
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+
+    auto [t1, t2, t3] = tinycoro::GetAll(scheduler, task(0), task(1), task(2));
+    
+    EXPECT_EQ(t1, 1);
+    EXPECT_EQ(t2, 2);
+    EXPECT_EQ(t3, 3);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_bad_alloc) 
+{
+    EXPECT_CALL(mock, allocate_bytes_noexcept).Times(1).WillRepeatedly([]([[maybe_unused]] size_t nbytes) { return nullptr; });
+    EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
+
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+    auto func = [&]{ std::ignore = tinycoro::RunInline(task(0)); }; 
+
+    EXPECT_THROW(func(), std::bad_alloc);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_bad_alloc_multi) 
+{
+    EXPECT_CALL(mock, allocate_bytes_noexcept).Times(1).WillRepeatedly([]([[maybe_unused]] size_t nbytes) { return nullptr; });
+    EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
+
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+    auto func = [&]{ std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); }; 
+
+    EXPECT_THROW(func(), std::bad_alloc);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi) 
+{
+    EXPECT_CALL(mock, allocate_bytes_noexcept)
+        .Times(2)
+        .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { return nullptr; });
+
+    EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
+
+    EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
+
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+    auto func = [&]{ std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); }; 
+
+    EXPECT_THROW(func(), std::bad_alloc);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_second_bad_alloc_multi_async) 
+{
+    tinycoro::Scheduler scheduler;
+
+    EXPECT_CALL(mock, allocate_bytes_noexcept)
+        .Times(2)
+        .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { return nullptr; });
+
+    EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
+
+    EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
+
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { i++; co_return i; };
+    auto func = [&]{ std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); }; 
+
+    EXPECT_THROW(func(), std::bad_alloc);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_throw_in_operator_new) 
+{
+    EXPECT_CALL(mock, allocate_bytes)
+        .Times(2)
+        .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { throw std::bad_alloc{}; return nullptr;});
+
+    EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
+
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> { i++; co_return i; };
+    auto func = [&]{ std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); }; 
+
+    EXPECT_THROW(func(), std::bad_alloc);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_throw_in_operator_new_async) 
+{
+    tinycoro::Scheduler scheduler;
+
+    EXPECT_CALL(mock, allocate_bytes)
+        .Times(2)
+        .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { throw std::bad_alloc{}; return nullptr; });
+
+    EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
+
+    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> { i++; co_return i; };
+    auto func = [&]{ std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); }; 
+
+    EXPECT_THROW(func(), std::bad_alloc);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_sync_await_throw) 
+{
+    tinycoro::Scheduler scheduler;
+
+    EXPECT_CALL(mock, allocate_bytes)
+        .Times(2)
+        .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { throw std::bad_alloc{}; return nullptr; });
+
+    EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
+
+    auto nestedTask = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> { co_return i; };
+
+    auto task = [&](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> { 
+        
+        // this need to throw std::bad_alloc
+        std::ignore = co_await tinycoro::SyncAwait(scheduler, nestedTask(0), nestedTask(1));
+        co_return ++i;
+    };
+    auto func = [&]{ std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); }; 
+
+    EXPECT_THROW(func(), std::bad_alloc);
+}
+
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_sync_await_throw_noexcept) 
+{
+    tinycoro::Scheduler scheduler;
+
+    EXPECT_CALL(mock, allocate_bytes_noexcept)
+        .Times(2)
+        .WillOnce([](size_t nbytes) { return std::malloc(nbytes); })
+        .WillRepeatedly([]([[maybe_unused]] size_t nbytes) { return nullptr; });
+
+    EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
+
+    // throw and exception
+    EXPECT_CALL(mock, get_return_object_on_allocation_failure).Times(1).WillRepeatedly([] { throw std::bad_alloc{}; });
+
+    auto nestedTask = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { co_return i; };
+
+    auto task = [&](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapterNoExcept> { 
+        
+        // this need to throw std::bad_alloc
+        std::ignore = co_await tinycoro::SyncAwait(scheduler, nestedTask(0), nestedTask(1));
+        co_return ++i;
+    };
+    auto func = [&]{ std::ignore = tinycoro::GetAll(scheduler, task(0), task(1), task(2)); }; 
+
+    EXPECT_THROW(func(), std::bad_alloc);
+}

--- a/test/src/AllocatorAdapterTest.cpp
+++ b/test/src/AllocatorAdapterTest.cpp
@@ -154,7 +154,7 @@ TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_throw_in_operator_new)
 
     EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });
 
-    auto task = [](int32_t i) -> tinycoro::Task<int32_t, AllocatorAdapter> { i++; co_return i; };
+    auto task = [](int32_t i) -> tinycoro::InlineTask<int32_t, AllocatorAdapter> { i++; co_return i; };
     auto func = [&]{ std::ignore = tinycoro::RunInline(task(0), task(1), task(2)); }; 
 
     EXPECT_THROW(func(), std::bad_alloc);

--- a/test/src/AsyncCallbackAwaiter_CStyle_test.cpp
+++ b/test/src/AsyncCallbackAwaiter_CStyle_test.cpp
@@ -22,7 +22,7 @@ struct AsyncCallbackAwaiter_CStyleTest : public testing::Test
 
     bool pauseHandlerCalled{false};
 
-    tinycoro::test::CoroutineHandleMock<tinycoro::Promise<T>> hdl;
+    tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<T>> hdl;
 };
 
 using AsyncCallbackAwaiter_CStyleTest_Int32 = AsyncCallbackAwaiter_CStyleTest<int32_t>;

--- a/test/src/AsyncCallbackAwaiter_test.cpp
+++ b/test/src/AsyncCallbackAwaiter_test.cpp
@@ -22,7 +22,7 @@ struct AsyncCallbackAwaiterTest : public testing::Test
 
     bool pauseHandlerCalled{false};
 
-    tinycoro::test::CoroutineHandleMock<tinycoro::Promise<T>> hdl;
+    tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<T>> hdl;
 };
 
 using AsyncCallbackAwaiterTest_Int32 = AsyncCallbackAwaiterTest<int32_t>;

--- a/test/src/Common_test.cpp
+++ b/test/src/Common_test.cpp
@@ -7,24 +7,26 @@
 #include <type_traits>
 #include <concepts>
 #include <tuple>
+#include <coroutine>
 
 #include <tinycoro/Common.hpp>
 #include <tinycoro/LinkedPtrStack.hpp>
 #include <tinycoro/LinkedUtils.hpp>
+#include <tinycoro/AllocatorAdapter.hpp>
 
-template<typename T>
+template <typename T>
 struct Concepts_IterableTest : public testing::Test
 {
     using value_type = T;
 };
 
 using IterableTypes = testing::Types<std::tuple<std::vector<int>, std::true_type>,
-                                         std::tuple<std::list<int>, std::true_type>,
-                                          std::tuple<std::array<int, 10>, std::true_type>,
-                                           std::tuple<std::map<int, int>, std::true_type>,
-                                           std::tuple<int, std::false_type>,
-                                           std::tuple<float, std::false_type>,
-                                           std::tuple<std::monostate, std::false_type>>;
+                                     std::tuple<std::list<int>, std::true_type>,
+                                     std::tuple<std::array<int, 10>, std::true_type>,
+                                     std::tuple<std::map<int, int>, std::true_type>,
+                                     std::tuple<int, std::false_type>,
+                                     std::tuple<float, std::false_type>,
+                                     std::tuple<std::monostate, std::false_type>>;
 
 TYPED_TEST_SUITE(Concepts_IterableTest, IterableTypes);
 
@@ -32,21 +34,10 @@ TYPED_TEST(Concepts_IterableTest, Concepts_IterableTest)
 {
     using T = typename TestFixture::value_type;
 
-    using firstParamT = std::decay_t<decltype(std::get<0>(std::declval<T>()))>;
-    using secondParamT = std::decay_t<decltype(std::get<1>(std::declval<T>()))>;
+    using first_t    = std::tuple_element<0, T>::type;
+    using expected_t = std::tuple_element<1, T>::type;
 
-    if constexpr (std::same_as<secondParamT, std::true_type>)
-    {
-        if constexpr (!tinycoro::concepts::Iterable<firstParamT>) {
-            EXPECT_FALSE(true)  << "Type not iterable!";   
-        }
-    }
-    else
-    {
-        if constexpr (tinycoro::concepts::Iterable<firstParamT>) {
-            EXPECT_FALSE(true)  << "Type is iterable but should be not!";  
-        }
-    }
+    EXPECT_EQ(tinycoro::concepts::Iterable<first_t>, expected_t::value);
 }
 
 struct NoVirtualDestructor
@@ -55,7 +46,7 @@ struct NoVirtualDestructor
 
 struct VirtualDestructor1
 {
-    virtual ~VirtualDestructor1() {}
+    virtual ~VirtualDestructor1() { }
 };
 
 struct VirtualDestructor2
@@ -68,16 +59,14 @@ struct NoVirtualDestructorAbstract
     virtual void foo() = 0;
 };
 
-
-template<typename T>
+template <typename T>
 struct Concepts_HasVirtualDestructor : public testing::Test
 {
     using value_type = T;
 };
 
-using HasVirtualDestructor_types = testing::Types<std::tuple<std::string, std::false_type>,
-                                                    std::tuple<NoVirtualDestructor, std::false_type>,
-                                                    std::tuple<VirtualDestructor1, std::true_type>>;
+using HasVirtualDestructor_types = testing::
+    Types<std::tuple<std::string, std::false_type>, std::tuple<NoVirtualDestructor, std::false_type>, std::tuple<VirtualDestructor1, std::true_type>>;
 
 TYPED_TEST_SUITE(Concepts_HasVirtualDestructor, HasVirtualDestructor_types);
 
@@ -85,17 +74,10 @@ TYPED_TEST(Concepts_HasVirtualDestructor, Concepts_HasVirtualDestructor)
 {
     using T = typename TestFixture::value_type;
 
-    using firstParamT = std::decay_t<decltype(std::get<0>(std::declval<T>()))>;
-    using secondParamT = std::decay_t<decltype(std::get<1>(std::declval<T>()))>;
+    using first_t    = std::tuple_element<0, T>::type;
+    using expected_t = std::tuple_element<1, T>::type;
 
-    if constexpr (std::same_as<secondParamT, std::true_type>)
-    {
-        EXPECT_TRUE((tinycoro::concepts::HasVirtualDestructor<firstParamT>)) << "Type has no virtual destructor!";
-    }
-    else
-    {
-        EXPECT_FALSE((tinycoro::concepts::HasVirtualDestructor<firstParamT>)) << "Type has virtual destructor!";
-    }
+    EXPECT_EQ(tinycoro::concepts::HasVirtualDestructor<first_t>, expected_t::value);
 }
 
 TEST(Concepts_HasVirtualDestructor, Concepts_HasVirtualDestructor_abstractClass_true)
@@ -147,7 +129,6 @@ TEST(Helper_ContainsTest, Helper_ContainsTest)
 
     Node n5{};
 
-
     tinycoro::detail::LinkedPtrStack<Node> list;
 
     list.push(&n1);
@@ -170,4 +151,53 @@ TEST(Helper_ContainsTest, Helper_ContainsTest)
 
     EXPECT_FALSE(tinycoro::detail::helper::Contains(list.top(), &n5));
     EXPECT_FALSE(tinycoro::detail::helper::Contains(list.top(), &n2));
+}
+
+template <typename>
+struct EmptyClass
+{
+};
+
+template <typename PromiseT>
+struct AllocatorAdapterNoexcept
+{
+    // ensure the use of non-throwing operator-new
+    [[noreturn]] static std::coroutine_handle<PromiseT> get_return_object_on_allocation_failure() { throw std::bad_alloc{}; }
+
+    [[nodiscard]] static void* operator new(size_t nbytes) noexcept { return std::malloc(nbytes); }
+
+    static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept { std::free(ptr); }
+};
+
+template <typename>
+struct AllocatorAdapterExcept
+{
+    [[nodiscard]] static void* operator new(size_t nbytes) { return std::malloc(nbytes); }
+
+    static void operator delete(void* ptr, [[maybe_unused]] size_t nbytes) noexcept { std::free(ptr); }
+};
+
+template <typename T>
+struct Concepts_AllocatorAdapter : testing::Test
+{
+    using value_type = T;
+};
+
+using AllocatorAdapterTyped = testing::Types<std::tuple<EmptyClass<int>, std::true_type>,
+                                             std::tuple<tinycoro::detail::NonAllocatorAdapter<int>, std::true_type>,
+                                             std::tuple<AllocatorAdapterNoexcept<int>, std::true_type>,
+                                             std::tuple<AllocatorAdapterExcept<int>, std::true_type>,
+                                             std::tuple<std::string, std::false_type>,
+                                             std::tuple<std::list<int>, std::false_type>>;
+
+TYPED_TEST_SUITE(Concepts_AllocatorAdapter, AllocatorAdapterTyped);
+
+TYPED_TEST(Concepts_AllocatorAdapter, Concepts_AllocatorAdapter)
+{
+    using tuple_t = typename TestFixture::value_type;
+
+    using first_t    = std::tuple_element<0, tuple_t>::type;
+    using expected_t = std::tuple_element<1, tuple_t>::type;
+
+    EXPECT_EQ(tinycoro::concepts::IsAllocatorAdapterT<first_t>, expected_t::value);
 }

--- a/test/src/PauseHandler_test.cpp
+++ b/test/src/PauseHandler_test.cpp
@@ -73,7 +73,7 @@ TYPED_TEST(Concepts_PauseHandlerTest, Concepts_PauseHandlerTest_test)
 
 TEST(PauseHandlerTest, CancellableSuspentTest_value)
 {
-    tinycoro::test::CoroutineHandleMock<tinycoro::Promise<int32_t>> hdl;
+    tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<int32_t>> hdl;
 
     bool called = false;
 

--- a/test/src/Promsie_test.cpp
+++ b/test/src/Promsie_test.cpp
@@ -185,3 +185,13 @@ TEST(PromiseTest, PromiseTest_not_trivial)
     auto&& s_copy2 = promise.value();
     EXPECT_EQ(s_copy2.i, s2.i);
 }
+
+TEST(PromiseTest, PromiseTest_assignment_from_optional_trivial)
+{
+    tinycoro::detail::PromiseReturnValue<int32_t, FinalAwaiterMock> promise;
+    std::optional<int32_t> val{42};
+
+    promise.return_value(val);
+
+    EXPECT_EQ(promise.value(), *val);
+}

--- a/test/src/Promsie_test.cpp
+++ b/test/src/Promsie_test.cpp
@@ -73,7 +73,7 @@ struct FinalAwaiterMock
 
 TEST(PromiseTest, PromiseTest_FinalAwaiter)
 {
-    tinycoro::detail::PromiseT<FinalAwaiterMock, tinycoro::detail::PromiseReturnValue<int32_t, FinalAwaiterMock>, tinycoro::PauseHandler, std::stop_source> promise;
+    tinycoro::detail::PromiseT<FinalAwaiterMock, tinycoro::detail::PromiseReturnValue<int32_t, FinalAwaiterMock>, tinycoro::PauseHandler, std::stop_source, tinycoro::detail::NonAllocatorAdapter> promise;
     EXPECT_TRUE(requires { promise.return_value(42); });
     EXPECT_TRUE(requires { typename decltype(promise)::value_type; });
 
@@ -89,7 +89,7 @@ TEST(PromiseTest, PromiseTest_FinalAwaiter)
 
 TEST(PromiseTest, PromiseTest_YieldValue)
 {
-    tinycoro::detail::PromiseT<FinalAwaiterMock, tinycoro::detail::PromiseReturnValue<int32_t, FinalAwaiterMock>, tinycoro::PauseHandler, std::stop_source> promise;
+    tinycoro::detail::PromiseT<FinalAwaiterMock, tinycoro::detail::PromiseReturnValue<int32_t, FinalAwaiterMock>, tinycoro::PauseHandler, std::stop_source, tinycoro::detail::NonAllocatorAdapter> promise;
     EXPECT_TRUE(requires { promise.return_value(42); });
     EXPECT_TRUE(requires { promise.yield_value(42); });
     EXPECT_TRUE(requires { typename decltype(promise)::value_type; });

--- a/test/src/Promsie_test.cpp
+++ b/test/src/Promsie_test.cpp
@@ -6,7 +6,7 @@
 
 TEST(PromiseTest, PromiseTest_void)
 {
-    tinycoro::Promise<void> promise;
+    tinycoro::detail::Promise<void> promise;
 
     EXPECT_TRUE(requires { promise.return_void(); });
     EXPECT_TRUE(requires { typename decltype(promise)::value_type; });
@@ -18,7 +18,7 @@ TEST(PromiseTest, PromiseTest_void)
 
 TEST(PromiseTest, PromiseTest_int)
 {
-    tinycoro::Promise<int32_t> promise;
+    tinycoro::detail::Promise<int32_t> promise;
     EXPECT_TRUE(requires { promise.return_value(42); });
     EXPECT_TRUE(requires { typename decltype(promise)::value_type; });
 
@@ -47,7 +47,7 @@ TEST(PromiseTest, PromiseTest_MoveOnly)
         int32_t i{};
     };
 
-    tinycoro::Promise<MoveOnly> promise;
+    tinycoro::detail::Promise<MoveOnly> promise;
 
     EXPECT_TRUE(requires { promise.return_value(MoveOnly{12}); });
     EXPECT_TRUE(requires { typename decltype(promise)::value_type; });

--- a/test/src/Semaphore_test.cpp
+++ b/test/src/Semaphore_test.cpp
@@ -17,7 +17,7 @@ template <typename T>
 struct SemaphoreMock
 {
     MOCK_METHOD(void, Release, ());
-    MOCK_METHOD(bool, TryAcquire, (void*, tinycoro::test::CoroutineHandleMock<tinycoro::Promise<T>>));
+    MOCK_METHOD(bool, TryAcquire, (void*, tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<T>>));
 };
 
 struct SemaphoreAwaiterTest : public testing::Test
@@ -35,7 +35,7 @@ struct SemaphoreAwaiterTest : public testing::Test
     }
 
     SemaphoreMock<value_type>                                          mock;
-    tinycoro::test::CoroutineHandleMock<tinycoro::Promise<value_type>> hdl;
+    tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<value_type>> hdl;
 
     tinycoro::detail::SemaphoreAwaiter<decltype(mock), tinycoro::detail::PauseCallbackEvent> awaiter;
 };
@@ -79,7 +79,7 @@ public:
     }
 
     MOCK_METHOD(void, Notify, (), (const));
-    MOCK_METHOD(void, PutOnPause, (tinycoro::test::CoroutineHandleMock<tinycoro::Promise<int32_t>>));
+    MOCK_METHOD(void, PutOnPause, (tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<int32_t>>));
 
     auto TestTryAcquire(auto parentCoro) { return semaphore.TryAcquire(this, parentCoro); }
 
@@ -96,7 +96,7 @@ struct EventMock
 struct SemaphoreTest : public testing::TestWithParam<size_t>
 {
     using semaphore_type  = tinycoro::detail::Semaphore<PopAwaiterMock, tinycoro::detail::LinkedPtrQueue>;
-    using corohandle_type = tinycoro::test::CoroutineHandleMock<tinycoro::Promise<int32_t>>;
+    using corohandle_type = tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<int32_t>>;
 
     void SetUp() override
     {

--- a/test/src/SyncAwaiter_test.cpp
+++ b/test/src/SyncAwaiter_test.cpp
@@ -99,7 +99,7 @@ struct SyncAwaiterTest : testing::Test
 
 protected:
     bool                                                         resumerCalled{false};
-    tinycoro::test::CoroutineHandleMock<tinycoro::Promise<void>> hdl;
+    tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<void>> hdl;
 
     SchedulerMock schedulerMock;
 };

--- a/test/src/mock/CoroutineHandleMock.h
+++ b/test/src/mock/CoroutineHandleMock.h
@@ -36,7 +36,7 @@ namespace tinycoro { namespace test {
     template<typename T = void>
     auto MakeCoroutineHdl(std::regular_invocable auto pauseResumerCallback)
     {
-        tinycoro::test::CoroutineHandleMock<tinycoro::Promise<T>> hdl;
+        tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<T>> hdl;
         hdl.promise().pauseHandler.emplace(pauseResumerCallback);
         return hdl;
     }
@@ -44,7 +44,7 @@ namespace tinycoro { namespace test {
     template<typename T = void>
     auto MakeCoroutineHdl()
     {
-        tinycoro::test::CoroutineHandleMock<tinycoro::Promise<T>> hdl;
+        tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<T>> hdl;
         hdl.promise().pauseHandler.emplace([]{});
         return hdl;
     }

--- a/test/src/mock/TaskMock.hpp
+++ b/test/src/mock/TaskMock.hpp
@@ -19,7 +19,7 @@ namespace tinycoro { namespace test {
         MOCK_METHOD(bool, IsDone, (), (const noexcept));
         MOCK_METHOD(void, SetPauseHandler, (tinycoro::PauseHandlerCallbackT));
         MOCK_METHOD(void*, Address, (), (const noexcept));
-        MOCK_METHOD(CoroutineHandleMock<tinycoro::Promise<void>>, Release, (), (noexcept));
+        MOCK_METHOD(CoroutineHandleMock<tinycoro::detail::Promise<void>>, Release, (), (noexcept));
 
         tinycoro::PauseHandlerCallbackT pauseCallback;
     };


### PR DESCRIPTION
Updated internal allocation routines to use constom AllocatorAdapter for:
- Coroutine frame memory (on creation)
- Destructor cleanup (on suspension completion/resume)
- Refactored internal API to carry allocator context where needed for symmetrical allocation and deallocation.
- Moving Promise and InlinePromise template aliases into the detail namespace. 
 
Added tests covering:
- Custom allocator usage
- Memory allocation/deallocation matching

