### PR TITLE
add std::max_align_t and remove heap allocation in AtomicQueue

### DIFF
--- a/include/tinycoro/SimpleStorage.hpp
+++ b/include/tinycoro/SimpleStorage.hpp
@@ -7,6 +7,7 @@
 #define TINY_CORO_SIMPLE_STORAGE_HPP
 
 #include <concepts>
+#include <cstddef>
 
 namespace tinycoro { namespace detail {
 
@@ -14,7 +15,7 @@ namespace tinycoro { namespace detail {
     //
     // It stores a simple object on his internal storage (stack).
     // It does not support copy or move operation.
-    template <std::unsigned_integral auto SIZE, typename AlignmentT = void*>
+    template <std::unsigned_integral auto SIZE, typename AlignmentT = std::max_align_t>
     class SimpleStorage
     {
         using Storage_t    = std::byte[SIZE];

--- a/test/src/AtomicQueue_test.cpp
+++ b/test/src/AtomicQueue_test.cpp
@@ -194,7 +194,7 @@ struct AtomicQueueFunctionalTest : testing::TestWithParam<size_t>
 {
 };
 
-INSTANTIATE_TEST_SUITE_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest, testing::Values(1, 10, 100, 1000, 10000));
+INSTANTIATE_TEST_SUITE_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest, testing::Values(1, 10, 100, 1000, 2000));
 
 TEST_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest_single_threaded)
 {
@@ -254,7 +254,7 @@ TEST_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest_multi_threaded)
 
     tinycoro::Scheduler scheduler;
 
-    tinycoro::detail::AtomicQueue<size_t, (1 << 17)> queue; // make sure you have enough cache size
+    tinycoro::detail::AtomicQueue<size_t, (1 << 15)> queue; // make sure you have enough cache size
 
     auto producer = [&]() -> tinycoro::Task<void> {
         for (auto i : std::views::iota(0u, count))
@@ -294,7 +294,7 @@ TEST_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest_multi_threaded_toget
 
     tinycoro::Scheduler scheduler;
 
-    tinycoro::detail::AtomicQueue<size_t, (1 << 17)> queue; // make sure you have enough cache size
+    tinycoro::detail::AtomicQueue<size_t, (1 << 15)> queue; // make sure you have enough cache size
 
     auto producer = [&]() -> tinycoro::Task<void> {
         for (auto i : std::views::iota(0u, count))


### PR DESCRIPTION
Some small improvements:
- introduce std::max_align_t to SimpleStorage
- remove heap allocation from AtomicQueue