### PR TITLE
introduce InlineAwait and AnyOfInlineAwait

### DIFF
--- a/include/tinycoro/AllocatorAdapter.hpp
+++ b/include/tinycoro/AllocatorAdapter.hpp
@@ -43,6 +43,9 @@ namespace tinycoro
         };
 
     } // namespace detail
+
+    template<typename T>
+    using DefaultAllocator = detail::NonAllocatorAdapter<T>;
     
 } // namespace tinycoro
 

--- a/include/tinycoro/CancellableSuspend.hpp
+++ b/include/tinycoro/CancellableSuspend.hpp
@@ -23,6 +23,24 @@ namespace tinycoro {
 
         constexpr void await_resume() const noexcept {}
     };
+
+    namespace this_coro
+    {   
+        // This yield is not cancellable
+        //
+        // If you need a yield which is cancellable
+        // use yield_cancellable().
+        constexpr auto yield() noexcept -> std::suspend_always
+        {
+            return {};
+        }
+
+        // A cancellable yield.
+        constexpr auto yield_cancellable() noexcept -> tinycoro::CancellableSuspend
+        {
+            return {};
+        }
+    }
     
 } // namespace tinycoro
 

--- a/include/tinycoro/InlineAwait.hpp
+++ b/include/tinycoro/InlineAwait.hpp
@@ -1,0 +1,150 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024 Tamas Kovacs
+//  Licensed under the MIT License – see LICENSE.txt for details.
+// -----------------------------------------------------------------------------
+
+#ifndef TINY_CORO_INLINE_AWAIT_HPP
+#define TINY_CORO_INLINE_AWAIT_HPP
+
+#include <tuple>
+#include <atomic>
+#include <stop_token>
+
+#include "Common.hpp"
+#include "RunInline.hpp"
+
+namespace tinycoro {
+    namespace detail {
+
+        struct InlineAwaitBase
+        {
+            InlineAwaitBase() = default;
+
+            // disallow copy and move
+            InlineAwaitBase(InlineAwaitBase&&) = delete;
+
+            // The awaiter is always ready,
+            // so jumping directly to await_resume.
+            [[nodiscard]] constexpr bool await_ready() const noexcept { return true; }
+
+            // this is probably never called
+            [[nodiscard]] constexpr bool await_suspend([[maybe_unused]] auto hdl) const noexcept { return false; }
+        };
+
+        template <typename...>
+        struct InlineAwaitT;
+
+        // Container specialization
+        template <concepts::Iterable ContainerT>
+        struct InlineAwaitT<ContainerT> : InlineAwaitBase
+        {
+            InlineAwaitT(ContainerT& container)
+            : _container{container}
+            {
+            }
+
+            [[nodiscard]] auto await_resume() { return tinycoro::RunInline(_container); }
+
+        private:
+            ContainerT& _container;
+        };
+
+        // Task specialization
+        template <concepts::IsCorouitneTask... Tasks>
+            requires (sizeof...(Tasks) > 0)
+        struct InlineAwaitT<Tasks...> : InlineAwaitBase
+        {
+            InlineAwaitT(Tasks&&... tasks)
+            : _tasks{std::forward_as_tuple(std::forward<Tasks>(tasks)...)}
+            {
+            }
+
+            [[nodiscard]] auto await_resume()
+            {
+                return std::apply([&]<typename... Args>(Args&&... tasks) { return tinycoro::RunInline(std::forward<Args>(tasks)...); }, _tasks);
+            }
+
+        private:
+            std::tuple<Tasks...> _tasks;
+        };
+
+        template <typename...>
+        struct AnyOfInlineAwaitT;
+
+        template <concepts::IsStopSource StopSourceT, concepts::IsCorouitneTask... Tasks>
+            requires (sizeof...(Tasks) > 0)
+        struct AnyOfInlineAwaitT<StopSourceT, Tasks...> : InlineAwaitBase
+        {
+            AnyOfInlineAwaitT(StopSourceT stopSource, Tasks&&... tasks)
+            : _tasks{std::forward_as_tuple(std::forward<Tasks>(tasks)...)}
+            , _stopSource{std::move(stopSource)}
+            {
+            }
+
+            [[nodiscard]] auto await_resume()
+            {
+                return std::apply([&]<typename... Args>(Args&&... tasks) { return tinycoro::AnyOfWithStopSourceInline(std::move(_stopSource), std::forward<Args>(tasks)...); }, _tasks);
+            }
+
+        private:
+            std::tuple<Tasks...> _tasks;
+            StopSourceT _stopSource;
+        };
+
+        template <concepts::IsStopSource StopSourceT, concepts::Iterable ContainerT>
+        struct AnyOfInlineAwaitT<StopSourceT, ContainerT> : InlineAwaitBase
+        {
+            AnyOfInlineAwaitT(StopSourceT stopSource, ContainerT& container)
+            : _container{container}
+            , _stopSource{std::move(stopSource)}
+            {
+            }
+
+            [[nodiscard]] auto await_resume() { return tinycoro::AnyOfWithStopSourceInline(std::move(_stopSource), _container); }
+
+        private:
+            ContainerT& _container;
+            StopSourceT _stopSource;
+        };
+
+        // Deduction quide for template specializations
+        //
+        // Implicitly generated deduction guides mirror
+        // the constructors of the primary template only,
+        // not of the specializations.
+        template<typename T>
+        InlineAwaitT(T) -> InlineAwaitT<T>;
+
+        template<typename... T>
+        InlineAwaitT(T...) -> InlineAwaitT<T...>;
+
+
+        template<typename S, typename T>
+        AnyOfInlineAwaitT(S, T) -> AnyOfInlineAwaitT<S, T>;
+
+        template<typename S, typename... T>
+        AnyOfInlineAwaitT(S, T...) -> AnyOfInlineAwaitT<S, T...>;
+
+    } // namespace detail
+
+    template <typename... Args>
+    [[nodiscard]] auto InlineAwait(Args&&... args)
+    {
+        return detail::InlineAwaitT{std::forward<Args>(args)...};
+    }
+
+    template <concepts::IsStopSource StopSourceT, typename... Args>
+    [[nodiscard]] auto AnyOfInlineAwait(StopSourceT& stopSource, Args&&... args)
+    {
+        return detail::AnyOfInlineAwaitT{stopSource, std::forward<Args>(args)...};
+    }
+
+    template <concepts::IsCorouitneTask... Args>
+    [[nodiscard]] auto AnyOfInlineAwait(Args&&... args)
+    {
+        return detail::AnyOfInlineAwaitT{std::stop_source{}, std::forward<Args>(args)...};
+    }
+
+} // namespace tinycoro
+
+#endif // TINY_CORO_INLINE_AWAIT_HPP

--- a/include/tinycoro/Promise.hpp
+++ b/include/tinycoro/Promise.hpp
@@ -236,14 +236,14 @@ namespace tinycoro {
         };
 
         template <typename ReturnValueT,
-                  template <typename> class AllocatorT = detail::NonAllocatorAdapter,
+                  template <typename> class AllocatorT = DefaultAllocator,
                   typename PauseHandlerT               = PauseHandler,
                   typename StopSourceT                 = std::stop_source>
         using Promise = detail::
             PromiseT<detail::FinalAwaiter, detail::PromiseReturnValue<ReturnValueT, detail::FinalAwaiter>, PauseHandlerT, StopSourceT, AllocatorT>;
 
         template <typename ReturnValueT,
-                  template <typename> class AllocatorT = detail::NonAllocatorAdapter,
+                  template <typename> class AllocatorT = DefaultAllocator,
                   typename PauseHandlerT               = PauseHandler,
                   typename StopSourceT                 = std::stop_source>
         using InlinePromise = detail::InlinePromiseT<detail::FinalAwaiter,

--- a/include/tinycoro/RunInline.hpp
+++ b/include/tinycoro/RunInline.hpp
@@ -293,7 +293,7 @@ namespace tinycoro {
         requires (sizeof...(TaskT) > 0)
     [[nodiscard]] auto AnyOfInline(TaskT&&... tasks)
     {
-        StopSourceT stopSource;
+        StopSourceT stopSource{};
         return AnyOfWithStopSourceInline(stopSource, std::forward<TaskT>(tasks)...);
     }
 

--- a/include/tinycoro/SleepAwaiter.hpp
+++ b/include/tinycoro/SleepAwaiter.hpp
@@ -13,6 +13,7 @@
 #include "CancellableSuspend.hpp"
 #include "AutoEvent.hpp"
 #include "AllocatorAdapter.hpp"
+#include "Common.hpp"
 
 using namespace std::chrono_literals;
 
@@ -33,8 +34,8 @@ namespace tinycoro {
 
     } // namespace concepts
 
-    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
-    Task<void, AllocatorAdapterT> SleepUntil(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint, concepts::IsStopToken auto stopToken)
+    template<template<typename> class AllocatorAdapterT = DefaultAllocator>
+    tinycoro::Task<void, AllocatorAdapterT> SleepUntil(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint, concepts::IsStopToken auto stopToken)
     {
         tinycoro::AutoEvent finished;
 
@@ -50,28 +51,28 @@ namespace tinycoro {
         co_await finished;
     }
 
-    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
-    Task<void, AllocatorAdapterT> SleepFor(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration, concepts::IsStopToken auto stopToken)
+    template<template<typename> class AllocatorAdapterT = DefaultAllocator>
+    tinycoro::Task<void, AllocatorAdapterT> SleepFor(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration, concepts::IsStopToken auto stopToken)
     {
         co_await SleepUntil<AllocatorAdapterT>(softClock, softClock.Now() + duration, stopToken);
     }
 
-    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
-    Task<void, AllocatorAdapterT> SleepFor(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration)
+    template<template<typename> class AllocatorAdapterT = DefaultAllocator>
+    tinycoro::Task<void, AllocatorAdapterT> SleepFor(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration)
     {
         auto stopToken = co_await this_coro::stop_token();
         co_await SleepFor<AllocatorAdapterT>(softClock, duration, stopToken);
     }
 
-    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
-    Task<void, AllocatorAdapterT> SleepUntil(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint)
+    template<template<typename> class AllocatorAdapterT = DefaultAllocator>
+    tinycoro::Task<void, AllocatorAdapterT> SleepUntil(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint)
     {
         auto stopToken = co_await this_coro::stop_token();
         co_await SleepUntil<AllocatorAdapterT>(softClock, timePoint, stopToken);
     }
     
-    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
-    Task<void, AllocatorAdapterT> SleepUntilCancellable(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint, concepts::IsStopToken auto stopToken)
+    template<template<typename> class AllocatorAdapterT = DefaultAllocator>
+    tinycoro::Task<void, AllocatorAdapterT> SleepUntilCancellable(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint, concepts::IsStopToken auto stopToken)
     {
         co_await SleepUntil<AllocatorAdapterT>(softClock, timePoint, stopToken);
 
@@ -81,21 +82,21 @@ namespace tinycoro {
         }
     }
 
-    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
-    Task<void, AllocatorAdapterT> SleepForCancellable(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration, concepts::IsStopToken auto stopToken)
+    template<template<typename> class AllocatorAdapterT = DefaultAllocator>
+    tinycoro::Task<void, AllocatorAdapterT> SleepForCancellable(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration, concepts::IsStopToken auto stopToken)
     {
         co_await SleepUntilCancellable<AllocatorAdapterT>(softClock, softClock.Now() + duration, stopToken);
     }
 
-    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
-    Task<void, AllocatorAdapterT> SleepForCancellable(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration)
+    template<template<typename> class AllocatorAdapterT = DefaultAllocator>
+    tinycoro::Task<void, AllocatorAdapterT> SleepForCancellable(concepts::IsSoftClock auto& softClock, concepts::IsDuration auto duration)
     {
         auto stopToken = co_await this_coro::stop_token();
         co_await SleepForCancellable<AllocatorAdapterT>(softClock, duration, stopToken);
     }
 
-    template<template<typename> class AllocatorAdapterT = detail::NonAllocatorAdapter>
-    Task<void, AllocatorAdapterT> SleepUntilCancellable(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint)
+    template<template<typename> class AllocatorAdapterT = DefaultAllocator>
+    tinycoro::Task<void, AllocatorAdapterT> SleepUntilCancellable(concepts::IsSoftClock auto& softClock, concepts::IsTimePoint auto timePoint)
     {
         auto stopToken = co_await this_coro::stop_token();
         co_await SleepUntilCancellable<AllocatorAdapterT>(softClock, timePoint, stopToken);

--- a/include/tinycoro/SyncAwait.hpp
+++ b/include/tinycoro/SyncAwait.hpp
@@ -17,201 +17,198 @@
 
 namespace tinycoro {
 
-    template <typename SchedulerT, typename EventT, typename FuturesT>
-    struct AsyncAwaiterBase
-    {
-        AsyncAwaiterBase(SchedulerT& scheduler, EventT event, size_t count)
-        : _scheduler{scheduler}
-        , _event{std::move(event)}
-        , _counter{count}
+    namespace detail {
+
+        template <typename SchedulerT, typename EventT, typename FuturesT>
+        struct AsyncAwaiterBase
         {
-        }
+            AsyncAwaiterBase(SchedulerT& scheduler, EventT event, size_t count)
+            : _scheduler{scheduler}
+            , _event{std::move(event)}
+            , _counter{count}
+            {
+            }
 
-        virtual ~AsyncAwaiterBase() = default;
+            virtual ~AsyncAwaiterBase() = default;
 
-        // disable copy and move
-        AsyncAwaiterBase(AsyncAwaiterBase&&) = delete;
+            // disable copy and move
+            AsyncAwaiterBase(AsyncAwaiterBase&&) = delete;
 
-        [[nodiscard]] constexpr bool await_ready() const noexcept { return false; }
+            [[nodiscard]] constexpr bool await_ready() const noexcept { return false; }
 
-        [[nodiscard]] auto await_resume() { return GetAll(this->_futures); }
+            [[nodiscard]] auto await_resume() { return GetAll(this->_futures); }
 
-    protected:
-        auto MakeDestroyNotifier()
+        protected:
+            auto MakeDestroyNotifier()
+            {
+                auto func = [](void* self) {
+                    auto* awaiter = static_cast<decltype(this)>(self);
+                    if (awaiter->_counter.fetch_sub(1, std::memory_order_relaxed) == 1)
+                    {
+                        awaiter->_event.Notify();
+                    }
+                };
+
+                return detail::UnsafeFunction<void(void*)>{func, this};
+            }
+
+            SchedulerT&         _scheduler;
+            EventT              _event;
+            std::atomic<size_t> _counter;
+
+            FuturesT _futures;
+        };
+
+        template <typename... Args>
+        struct AsyncAwaiterT;
+
+        template <typename SchedulerT, typename EventT, typename FuturesT, concepts::IsCorouitneTask... Args>
+        struct AsyncAwaiterT<SchedulerT, EventT, FuturesT, Args...> : public AsyncAwaiterBase<SchedulerT, EventT, FuturesT>
         {
-            auto func = [](void* self) {
-                auto* awaiter = static_cast<decltype(this)>(self);
-                if (awaiter->_counter.fetch_sub(1) == 1)
-                {
-                    awaiter->_event.Notify();
-                }
-            };
+            AsyncAwaiterT(SchedulerT& scheduler, EventT event, Args&&... args)
+            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, sizeof...(Args)}
+            , _coroutineTasks(std::forward<Args>(args)...)
+            {
+            }
 
-            return detail::UnsafeFunction<void(void*)>{func, this};
+            void await_suspend(auto hdl)
+            {
+                // put tast on pause
+                this->_event.Set(context::PauseTask(hdl));
 
-            /*return [this] {
-                if (this->_counter.fetch_sub(1) == 1)
-                {
-                    this->_event.Notify();
-                }
-            };*/
-        }
+                auto destroyNotifier = this->MakeDestroyNotifier();
 
-        SchedulerT&          _scheduler;
-        EventT               _event;
-        std::atomic<size_t>  _counter;
-
-        FuturesT _futures;
-    };
-
-    template <typename... Args>
-    struct AsyncAwaiterT;
-
-    template <typename SchedulerT, typename EventT, typename FuturesT, concepts::IsCorouitneTask... Args>
-    struct AsyncAwaiterT<SchedulerT, EventT, FuturesT, Args...> : public AsyncAwaiterBase<SchedulerT, EventT, FuturesT>
-    {
-        AsyncAwaiterT(SchedulerT& scheduler, EventT event, Args&&... args)
-        : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, sizeof...(Args)}
-        , _coroutineTasks(std::forward<Args>(args)...)
-        {
-        }
-
-        void await_suspend(auto hdl)
-        {
-            // put tast on pause
-            this->_event.Set(context::PauseTask(hdl));
-
-            auto destroyNotifier = this->MakeDestroyNotifier();
-
-            // start all coroutines
-            this->_futures = std::apply(
-                [destroyNotifier, this]<typename... Ts>(Ts&&... ts) {
-                    (ts.SetDestroyNotifier(destroyNotifier), ...);
-                    return this->_scheduler.Enqueue(std::forward<Ts>(ts)...);
-                },
-                std::move(this->_coroutineTasks));
-        }
+                // start all coroutines
+                this->_futures = std::apply(
+                    [destroyNotifier, this]<typename... Ts>(Ts&&... ts) {
+                        (ts.SetDestroyNotifier(destroyNotifier), ...);
+                        return this->_scheduler.Enqueue(std::forward<Ts>(ts)...);
+                    },
+                    std::move(this->_coroutineTasks));
+            }
 
         private:
-            std::tuple<Args...>   _coroutineTasks;
-    };
+            std::tuple<Args...> _coroutineTasks;
+        };
 
-    template <typename SchedulerT, typename EventT, typename FuturesT, concepts::Iterable ContainerT>
-    struct AsyncAwaiterT<SchedulerT, EventT, FuturesT, ContainerT> : public AsyncAwaiterBase<SchedulerT, EventT, FuturesT>
-    {
-        AsyncAwaiterT(SchedulerT& scheduler, EventT event, ContainerT&& container)
-        : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, std::size(container)}
-        , _container{std::forward<ContainerT>(container)}
+        template <typename SchedulerT, typename EventT, typename FuturesT, concepts::Iterable ContainerT>
+        struct AsyncAwaiterT<SchedulerT, EventT, FuturesT, ContainerT> : public AsyncAwaiterBase<SchedulerT, EventT, FuturesT>
         {
-        }
-
-        void await_suspend(auto hdl)
-        {
-            // put tast on pause
-            this->_event.Set(context::PauseTask(hdl));
-
-            auto destroyNotifier = this->MakeDestroyNotifier();
-
-            // setting the destroy notifier callback
-            for(auto& it : _container)
+            AsyncAwaiterT(SchedulerT& scheduler, EventT event, ContainerT&& container)
+            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, std::size(container)}
+            , _container{std::forward<ContainerT>(container)}
             {
-                it.SetDestroyNotifier(destroyNotifier);
             }
 
-            // start all coroutines
-            this->_futures = this->_scheduler.Enqueue(std::move(_container));
-        }
-
-    private:
-        ContainerT&& _container;
-    };
-
-    template <typename... Args>
-    struct AsyncAnyOfAwaiterT;
-
-    template <typename SchedulerT, typename StopSourceT, typename EventT, typename FuturesT, concepts::IsCorouitneTask... Args>
-    struct AsyncAnyOfAwaiterT<SchedulerT, StopSourceT, EventT, FuturesT, Args...> : public AsyncAwaiterBase<SchedulerT, EventT, FuturesT>
-    {
-        AsyncAnyOfAwaiterT(SchedulerT& scheduler, StopSourceT stopSource, EventT event, Args&&... args)
-        : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, sizeof...(Args)}
-        , _stopSource{std::move(stopSource)}
-        , _coroutineTasks(std::forward<Args>(args)...)
-        {
-        }
-
-        void await_suspend(auto hdl)
-        {
-            // put tast on pause
-            this->_event.Set(context::PauseTask(hdl));
-
-            auto destroyNotifier = this->MakeDestroyNotifier();
-
-            // start all coroutines
-            this->_futures = std::apply(
-                [destroyNotifier, this]<typename... Ts>(Ts&&... ts) {
-                    ((ts.SetDestroyNotifier(destroyNotifier), ts.SetStopSource(_stopSource)), ...);
-                    return this->_scheduler.Enqueue(std::forward<Ts>(ts)...);
-                },
-                std::move(this->_coroutineTasks));
-        }
-
-    private:
-        StopSourceT _stopSource;
-        std::tuple<Args...>   _coroutineTasks;
-    };
-
-    template <typename SchedulerT, typename StopSourceT, typename EventT, typename FuturesT, concepts::Iterable ContainerT>
-    struct AsyncAnyOfAwaiterT<SchedulerT, StopSourceT, EventT, FuturesT, ContainerT> : public AsyncAwaiterBase<SchedulerT, EventT, FuturesT>
-    {
-        AsyncAnyOfAwaiterT(SchedulerT& scheduler, StopSourceT stopSource, EventT event, ContainerT&& container)
-        : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, std::size(container)}
-        , _stopSource{std::move(stopSource)}
-        , _container{std::forward<ContainerT>(container)}
-        {
-        }
-
-        void await_suspend(auto hdl)
-        {
-            // put tast on pause
-            this->_event.Set(context::PauseTask(hdl));
-
-            auto destroyNotifier = this->MakeDestroyNotifier();
-
-            // setting the destroy notifier callback
-            for(auto& it : _container)
+            void await_suspend(auto hdl)
             {
-                it.SetDestroyNotifier(destroyNotifier);
-                it.SetStopSource(_stopSource);
+                // put tast on pause
+                this->_event.Set(context::PauseTask(hdl));
+
+                auto destroyNotifier = this->MakeDestroyNotifier();
+
+                // setting the destroy notifier callback
+                for (auto& it : _container)
+                {
+                    it.SetDestroyNotifier(destroyNotifier);
+                }
+
+                // start all coroutines
+                this->_futures = this->_scheduler.Enqueue(std::move(_container));
             }
 
-            // start all coroutines
-            this->_futures = this->_scheduler.Enqueue(std::move(_container));
-        }
+        private:
+            ContainerT&& _container;
+        };
 
-    private:
-        StopSourceT  _stopSource;
-        ContainerT&& _container;
-    };
+        template <typename... Args>
+        struct AsyncAnyOfAwaiterT;
+
+        template <typename SchedulerT, typename StopSourceT, typename EventT, typename FuturesT, concepts::IsCorouitneTask... Args>
+        struct AsyncAnyOfAwaiterT<SchedulerT, StopSourceT, EventT, FuturesT, Args...> : public AsyncAwaiterBase<SchedulerT, EventT, FuturesT>
+        {
+            AsyncAnyOfAwaiterT(SchedulerT& scheduler, StopSourceT stopSource, EventT event, Args&&... args)
+            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, sizeof...(Args)}
+            , _stopSource{std::move(stopSource)}
+            , _coroutineTasks(std::forward<Args>(args)...)
+            {
+            }
+
+            void await_suspend(auto hdl)
+            {
+                // put tast on pause
+                this->_event.Set(context::PauseTask(hdl));
+
+                auto destroyNotifier = this->MakeDestroyNotifier();
+
+                // start all coroutines
+                this->_futures = std::apply(
+                    [destroyNotifier, this]<typename... Ts>(Ts&&... ts) {
+                        ((ts.SetDestroyNotifier(destroyNotifier), ts.SetStopSource(_stopSource)), ...);
+                        return this->_scheduler.Enqueue(std::forward<Ts>(ts)...);
+                    },
+                    std::move(this->_coroutineTasks));
+            }
+
+        private:
+            StopSourceT         _stopSource;
+            std::tuple<Args...> _coroutineTasks;
+        };
+
+        template <typename SchedulerT, typename StopSourceT, typename EventT, typename FuturesT, concepts::Iterable ContainerT>
+        struct AsyncAnyOfAwaiterT<SchedulerT, StopSourceT, EventT, FuturesT, ContainerT> : public AsyncAwaiterBase<SchedulerT, EventT, FuturesT>
+        {
+            AsyncAnyOfAwaiterT(SchedulerT& scheduler, StopSourceT stopSource, EventT event, ContainerT&& container)
+            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, std::size(container)}
+            , _stopSource{std::move(stopSource)}
+            , _container{std::forward<ContainerT>(container)}
+            {
+            }
+
+            void await_suspend(auto hdl)
+            {
+                // put tast on pause
+                this->_event.Set(context::PauseTask(hdl));
+
+                auto destroyNotifier = this->MakeDestroyNotifier();
+
+                // setting the destroy notifier callback
+                for (auto& it : _container)
+                {
+                    it.SetDestroyNotifier(destroyNotifier);
+                    it.SetStopSource(_stopSource);
+                }
+
+                // start all coroutines
+                this->_futures = this->_scheduler.Enqueue(std::move(_container));
+            }
+
+        private:
+            StopSourceT  _stopSource;
+            ContainerT&& _container;
+        };
+
+    } // namespace detail
 
     template <typename SchedulerT, concepts::Iterable ContainerT>
     [[nodiscard]] auto SyncAwait(SchedulerT& scheduler, ContainerT&& container)
     {
         using FuturesType = decltype(std::declval<SchedulerT>().Enqueue(std::move(container)));
-        return AsyncAwaiterT<SchedulerT, detail::PauseCallbackEvent, FuturesType, ContainerT>{scheduler, {}, std::forward<ContainerT>(container)};
+        return detail::AsyncAwaiterT<SchedulerT, detail::PauseCallbackEvent, FuturesType, ContainerT>{scheduler, {}, std::forward<ContainerT>(container)};
     }
 
     template <typename SchedulerT, concepts::IsCorouitneTask... Args>
     [[nodiscard]] auto SyncAwait(SchedulerT& scheduler, Args&&... args)
     {
         using FutureTupleType = decltype(std::declval<SchedulerT>().Enqueue(std::forward<Args>(args)...));
-        return AsyncAwaiterT<SchedulerT, detail::PauseCallbackEvent, FutureTupleType, Args...>{scheduler, {}, std::forward<Args>(args)...};
+        return detail::AsyncAwaiterT<SchedulerT, detail::PauseCallbackEvent, FutureTupleType, Args...>{scheduler, {}, std::forward<Args>(args)...};
     }
 
     template <typename SchedulerT, typename StopSourceT, concepts::Iterable ContainerT>
     [[nodiscard]] auto AnyOfStopSourceAwait(SchedulerT& scheduler, StopSourceT stopSource, ContainerT&& container)
     {
         using FuturesType = decltype(std::declval<SchedulerT>().Enqueue(std::move(container)));
-        return AsyncAnyOfAwaiterT<SchedulerT, StopSourceT, detail::PauseCallbackEvent, FuturesType, ContainerT>{
+        return detail::AsyncAnyOfAwaiterT<SchedulerT, StopSourceT, detail::PauseCallbackEvent, FuturesType, ContainerT>{
             scheduler, std::move(stopSource), {}, std::forward<ContainerT>(container)};
     }
 
@@ -219,7 +216,7 @@ namespace tinycoro {
     [[nodiscard]] auto AnyOfStopSourceAwait(SchedulerT& scheduler, StopSourceT stopSource, Args&&... args)
     {
         using FutureTupleType = decltype(std::declval<SchedulerT>().Enqueue(std::forward<Args>(args)...));
-        return AsyncAnyOfAwaiterT<SchedulerT, StopSourceT, detail::PauseCallbackEvent, FutureTupleType, Args...>{
+        return detail::AsyncAnyOfAwaiterT<SchedulerT, StopSourceT, detail::PauseCallbackEvent, FutureTupleType, Args...>{
             scheduler, std::move(stopSource), {}, std::forward<Args>(args)...};
     }
 

--- a/include/tinycoro/tinycoro_all.h
+++ b/include/tinycoro/tinycoro_all.h
@@ -31,5 +31,6 @@
 #include "UnbufferedChannel.hpp"
 #include "SoftClock.hpp"
 #include "Cancellable.hpp"
+#include "InlineAwait.hpp"
 
 #endif // TINY_CORO_TINY_CORO_ALL_H

--- a/test/src/AutoEvent_test.cpp
+++ b/test/src/AutoEvent_test.cpp
@@ -185,18 +185,18 @@ TEST_P(AutoEventTest, AutoEventFunctionalTest_set_and_cancel)
 
     tinycoro::AutoEvent autoEvent{true};
 
-    auto autoEventConsumer = [&]() -> tinycoro::Task<int32_t> {
+    auto autoEventConsumer = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(autoEvent.Wait());
         autoEvent.Set();
         co_return 42;
     };
 
-    auto sleep = [&]()->tinycoro::Task<int32_t> {
+    auto sleep = [&]()->tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::SleepFor(clock, 50ms);
         co_return 44;
     };  
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t>> tasks;
     tasks.reserve(count + 1);
     tasks.push_back(sleep());
     for (size_t i = 0; i < count; ++i)
@@ -219,17 +219,17 @@ TEST_P(AutoEventTest, AutoEventFunctionalTest_cancel)
     tinycoro::AutoEvent autoEvent;
     int32_t              autoCount{};
 
-    auto autoEventConsumer = [&]() -> tinycoro::Task<int32_t> {
-        co_await tinycoro::Cancellable(autoEvent.Wait());
+    auto autoEventConsumer = [&]() -> tinycoro::TaskNIC<int32_t> {
+        co_await tinycoro::Cancellable{autoEvent.Wait()};
         co_return autoCount++;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<int32_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::SleepFor(clock, 100ms);
         co_return ++autoCount;
     };
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t>> tasks;
     tasks.reserve(count + 1);
     tasks.push_back(sleep());
     for (size_t i = 0; i < count; ++i)
@@ -256,17 +256,17 @@ TEST_P(AutoEventTest, AutoEventFunctionalTest_cancel_AnyOfInline)
     tinycoro::AutoEvent autoEvent;
     int32_t              autoCount{};
 
-    auto autoEventConsumer = [&]() -> tinycoro::Task<int32_t> {
+    auto autoEventConsumer = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(autoEvent.Wait());
         co_return autoCount++;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<int32_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::SleepFor(clock, 100ms);
         co_return ++autoCount;
     };
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t>> tasks;
     tasks.reserve(count + 1);
     tasks.push_back(sleep());
     for (size_t i = 0; i < count; ++i)

--- a/test/src/Barrier_test.cpp
+++ b/test/src/Barrier_test.cpp
@@ -515,7 +515,7 @@ TEST(BarrierTest, BarrierTest_functionalTest_cancel_scheduler)
 
     tinycoro::Barrier barrier{10};
 
-    auto task = [&]() -> tinycoro::Task<int32_t> {
+    auto task = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(barrier.Wait());
         co_return 42;
     };
@@ -539,13 +539,18 @@ TEST_P(BarrierTest, BarrierTest_cancel_multi)
 
     tinycoro::Barrier barrier{count * 3};
 
-    auto task1 = [&]() -> tinycoro::Task<void> { co_await tinycoro::Cancellable(barrier.Wait()); };
-    auto task2 = [&]() -> tinycoro::Task<void> { co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
-    auto task3 = [&]() -> tinycoro::Task<void> { co_await tinycoro::Cancellable(barrier.ArriveDropAndWait()); };
+    auto task1 = [&]() -> tinycoro::TaskNIC<void> { co_await tinycoro::Cancellable(barrier.Wait()); };
+    auto task2 = [&]() -> tinycoro::TaskNIC<void> { co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
+    auto task3 = [&]() -> tinycoro::TaskNIC<void> { co_await tinycoro::Cancellable(barrier.ArriveDropAndWait()); };
 
-    std::vector<tinycoro::Task<void>> tasks;
+    auto sleep = [&]() -> tinycoro::TaskNIC<void>
+    {
+        co_await tinycoro::SleepFor(clock, 100ms);
+    };
+
+    std::vector<tinycoro::TaskNIC<void>> tasks;
     tasks.reserve((count * 3) + 1);
-    tasks.emplace_back(tinycoro::SleepFor(clock, 100ms));
+    tasks.emplace_back(sleep());
     for (size_t i = 0; i < count; ++i)
     {
         tasks.emplace_back(task1());
@@ -556,18 +561,32 @@ TEST_P(BarrierTest, BarrierTest_cancel_multi)
     EXPECT_NO_THROW(tinycoro::AnyOf(scheduler, std::move(tasks)));
 }
 
-TEST(BarrierTest, BarrierTest_preset_stopSource)
+TEST(BarrierTest, BarrierTest_preset_stopSource_cancel)
 {
     tinycoro::Scheduler scheduler;
     tinycoro::Barrier barrier{1};
 
     std::stop_source stopSource;
 
-    auto task1 = [&]() -> tinycoro::Task<void> { co_await tinycoro::Cancellable(barrier.Wait()); };
-    auto task2 = [&]() -> tinycoro::Task<void> { co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
+    std::atomic<size_t> count{};
+
+    auto task1 = [&]() -> tinycoro::Task<void> { count++; co_await tinycoro::Cancellable(barrier.Wait()); };
+    auto task2 = [&]() -> tinycoro::Task<void> { count++; co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
 
     stopSource.request_stop();
     tinycoro::AnyOfWithStopSource(scheduler, stopSource, task2(), task1());
+
+    // all the coroutines are cancelled before the execution.
+    EXPECT_EQ(count, 0);
+
+    auto taskNic1 = [&]() -> tinycoro::TaskNIC<void> { count++; co_await tinycoro::Cancellable(barrier.Wait()); };
+    auto taskNic2 = [&]() -> tinycoro::TaskNIC<void> { count++; co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
+
+    tinycoro::AnyOfWithStopSource(scheduler, stopSource, taskNic1(), taskNic2());
+
+    // The tasks are not initiali cancellable
+    // so they will run and increase the count variable.
+    EXPECT_EQ(count, 2);
 }
 
 TEST(BarrierTest, BarrierTest_preset_stopSource_inline)
@@ -577,11 +596,22 @@ TEST(BarrierTest, BarrierTest_preset_stopSource_inline)
 
     std::stop_source stopSource;
 
-    auto task1 = [&]() -> tinycoro::Task<void> { co_await tinycoro::Cancellable(barrier.Wait()); };
-    auto task2 = [&]() -> tinycoro::Task<void> { co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
+    std::atomic<size_t> count{};
+
+    auto task1 = [&]() -> tinycoro::Task<void> { count++; co_await tinycoro::Cancellable(barrier.Wait()); };
+    auto task2 = [&]() -> tinycoro::Task<void> { count++; co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
 
     stopSource.request_stop();
     tinycoro::AnyOfWithStopSourceInline(stopSource, task2(), task1());
+
+    EXPECT_EQ(count, 0);
+
+    auto taskNic1 = [&]() -> tinycoro::TaskNIC<void> { count++; co_await tinycoro::Cancellable(barrier.Wait()); };
+    auto taskNic2 = [&]() -> tinycoro::TaskNIC<void> { count++; co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
+
+    tinycoro::AnyOfWithStopSourceInline(stopSource, taskNic2(), taskNic1());
+
+    EXPECT_EQ(count, 2);
 }
 
 TEST(BarrierTest, BarrierTest_functionalTest_cancel_inline)
@@ -590,7 +620,7 @@ TEST(BarrierTest, BarrierTest_functionalTest_cancel_inline)
 
     tinycoro::Barrier barrier{10};
 
-    auto task = [&]() -> tinycoro::Task<int32_t> {
+    auto task = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(barrier.Wait());
         co_return 42;
     };

--- a/test/src/CancellableSuspend_test.cpp
+++ b/test/src/CancellableSuspend_test.cpp
@@ -5,20 +5,6 @@
 
 #include "mock/CoroutineHandleMock.h"
 
-
-/*TEST(CancellableSuspentTest, CancellableSuspentTest_value)
-{
-    int32_t val{42};
-    tinycoro::CancellableSuspend suspend{val};
-
-    auto hdl = tinycoro::test::MakeCoroutineHdl<int32_t>([]{});
-
-    suspend.await_suspend(hdl);
-
-    EXPECT_TRUE(hdl.promise().pauseHandler->IsCancellable());
-    EXPECT_EQ(hdl.promise().value(), 42);
-}*/
-
 TEST(CancellableSuspentTest, CancellableSuspentTest)
 {
     tinycoro::CancellableSuspend suspend{};

--- a/test/src/Common_test.cpp
+++ b/test/src/Common_test.cpp
@@ -184,7 +184,7 @@ struct Concepts_AllocatorAdapter : testing::Test
 };
 
 using AllocatorAdapterTyped = testing::Types<std::tuple<EmptyClass<int>, std::true_type>,
-                                             std::tuple<tinycoro::detail::NonAllocatorAdapter<int>, std::true_type>,
+                                             std::tuple<tinycoro::DefaultAllocator<int>, std::true_type>,
                                              std::tuple<AllocatorAdapterNoexcept<int>, std::true_type>,
                                              std::tuple<AllocatorAdapterExcept<int>, std::true_type>,
                                              std::tuple<std::string, std::false_type>,

--- a/test/src/Example_tests.cpp
+++ b/test/src/Example_tests.cpp
@@ -584,7 +584,7 @@ TEST_F(ExampleTest, Example_AnyOfVoid)
     auto task1 = [](auto duration) -> tinycoro::Task<void> {
         for (auto start = std::chrono::system_clock::now(); std::chrono::system_clock::now() - start < duration;)
         {
-            co_await tinycoro::CancellableSuspend{};
+            co_await tinycoro::this_coro::yield_cancellable();
         }
     };
 
@@ -599,7 +599,7 @@ TEST_F(ExampleTest, Example_AnyOf)
 
         for (auto start = std::chrono::system_clock::now(); std::chrono::system_clock::now() - start < duration;)
         {
-            co_await tinycoro::CancellableSuspend{};
+            co_await tinycoro::this_coro::yield_cancellable();
             count++;
         }
         co_return count;
@@ -627,7 +627,7 @@ TEST_F(ExampleTest, Example_AnyOfDynamic)
 
         for (auto start = std::chrono::system_clock::now(); std::chrono::system_clock::now() - start < duration;)
         {
-            co_await tinycoro::CancellableSuspend{};
+            co_await tinycoro::this_coro::yield_cancellable();
             count++;
         }
         co_return count;
@@ -671,7 +671,7 @@ TEST_F(ExampleTest, Example_AnyOfVoidException)
     auto task1 = [](auto duration) -> tinycoro::Task<void> {
         for (auto start = std::chrono::system_clock::now(); std::chrono::system_clock::now() - start < duration;)
         {
-            co_await tinycoro::CancellableSuspend{};
+            co_await tinycoro::this_coro::yield_cancellable();
         }
     };
 
@@ -679,7 +679,7 @@ TEST_F(ExampleTest, Example_AnyOfVoidException)
         for (auto start = std::chrono::system_clock::now(); std::chrono::system_clock::now() - start < duration;)
         {
             throw std::runtime_error("Exception throwed!");
-            co_await tinycoro::CancellableSuspend{};
+            co_await tinycoro::this_coro::yield_cancellable();
         }
         co_return 42;
     };
@@ -798,7 +798,7 @@ TEST_F(ExampleTest, ExampleAnyOfCoAwait)
 
             for (auto start = std::chrono::system_clock::now(); std::chrono::system_clock::now() - start < duration;)
             {
-                co_await tinycoro::CancellableSuspend{};
+                co_await tinycoro::this_coro::yield_cancellable();
                 count++;
             }
             co_return count;

--- a/test/src/InlineAwait_test.cpp
+++ b/test/src/InlineAwait_test.cpp
@@ -1,0 +1,361 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <stdexcept>
+
+#include <tinycoro/tinycoro_all.h>
+
+TEST(InlineAwaitTest, InlineAwaitTest_tasks_int_return)
+{
+    auto task = [](int32_t val) -> tinycoro::InlineTask<int32_t> { co_return val; };
+
+    auto awaitable = tinycoro::InlineAwait(task(40), task(41), task(42));
+
+    EXPECT_TRUE(awaitable.await_ready());
+    EXPECT_FALSE(awaitable.await_suspend(int32_t{}));
+
+    auto [r1, r2, r3] = awaitable.await_resume();
+    EXPECT_EQ(r1, 40);
+    EXPECT_EQ(r2, 41);
+    EXPECT_EQ(r3, 42);
+}
+
+TEST(InlineAwaitTest, InlineAwaitTest_tasks_int_return_single_task)
+{
+    auto task = [](int32_t val) -> tinycoro::InlineTask<int32_t> { co_return val; };
+
+    auto awaitable = tinycoro::InlineAwait(task(42));
+
+    EXPECT_TRUE(awaitable.await_ready());
+    EXPECT_FALSE(awaitable.await_suspend(int32_t{}));
+
+    auto r1 = awaitable.await_resume();
+    EXPECT_EQ(r1, 42);
+}
+
+TEST(InlineAwaitTest, InlineAwaitTest_tasks_void_return)
+{
+    size_t count{0};
+
+    auto task = [&]() -> tinycoro::InlineTask<> {
+        count++;
+        co_return;
+    };
+
+    auto awaitable = tinycoro::InlineAwait(task(), task(), task());
+
+    EXPECT_TRUE(awaitable.await_ready());
+    EXPECT_FALSE(awaitable.await_suspend(int32_t{}));
+
+    awaitable.await_resume();
+    EXPECT_EQ(count, 3);
+}
+
+TEST(InlineAwaitTest, InlineAwaitTest_container_int_return)
+{
+    auto task = [](int32_t val) -> tinycoro::InlineTask<int32_t> { co_return val; };
+
+    std::vector<tinycoro::InlineTask<int32_t>> container;
+    container.push_back(task(40));
+    container.push_back(task(41));
+    container.push_back(task(42));
+
+    auto awaitable = tinycoro::InlineAwait(container);
+
+    EXPECT_TRUE(awaitable.await_ready());
+    EXPECT_FALSE(awaitable.await_suspend(int32_t{}));
+
+    auto result = awaitable.await_resume();
+    EXPECT_EQ(result[0], 40);
+    EXPECT_EQ(result[1], 41);
+    EXPECT_EQ(result[2], 42);
+}
+
+TEST(InlineAwaitTest, InlineAwaitTest_container_void_return)
+{
+    size_t count{0};
+
+    auto task = [&]() -> tinycoro::InlineTask<> {
+        count++;
+        co_return;
+    };
+
+    std::vector<tinycoro::InlineTask<>> container{};
+    container.push_back(task());
+    container.push_back(task());
+    container.push_back(task());
+
+    auto awaitable = tinycoro::InlineAwait(container);
+
+    EXPECT_TRUE(awaitable.await_ready());
+    EXPECT_FALSE(awaitable.await_suspend(int32_t{}));
+
+    awaitable.await_resume();
+    EXPECT_EQ(count, 3);
+}
+
+TEST(InlineAwaitTest, InlineAwaitTest_coawait)
+{
+    auto task = [](int32_t val) -> tinycoro::InlineTask<int32_t> { co_return val; };
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<int32_t> {
+        auto [r1, r2, r3] = co_await tinycoro::InlineAwait(task(40), task(41), task(42));
+        co_return *r1 + *r2 + *r3;
+    };
+
+    auto result = tinycoro::RunInline(wrapper());
+
+    EXPECT_EQ(123, result);
+}
+
+TEST(InlineAwaitTest, InlineAwaitTest_coawait_exception)
+{
+    auto task = [](int32_t val) -> tinycoro::InlineTask<int32_t> {
+        throw std::runtime_error{"error"};
+        co_return val;
+    };
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<int32_t> {
+        auto [r1, r2, r3] = co_await tinycoro::InlineAwait(task(40), task(41), task(42));
+        co_return *r1 + *r2 + *r3;
+    };
+
+    auto func = [&] { std::ignore = tinycoro::RunInline(wrapper()); };
+    EXPECT_THROW(func(), std::runtime_error);
+}
+
+TEST(InlineAwaitTest, InlineAwaitTest_coawait_container)
+{
+    auto task = [](int32_t val) -> tinycoro::InlineTask<int32_t> { co_return val; };
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<int32_t> {
+        std::vector<tinycoro::InlineTask<int32_t>> vec;
+        vec.push_back(task(40));
+        vec.push_back(task(41));
+        vec.push_back(task(42));
+
+        auto res = co_await tinycoro::InlineAwait(vec);
+        co_return res[0].value() + res[1].value() + res[2].value();
+    };
+
+    auto result = tinycoro::RunInline(wrapper());
+
+    EXPECT_EQ(123, result);
+}
+
+TEST(InlineAwaitTest, InlineAwaitTest_coawait_container_void)
+{
+    size_t count{0};
+
+    auto task = [](size_t& c) -> tinycoro::InlineTask<> {
+        c++;
+        co_return;
+    };
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<> {
+        std::vector<tinycoro::InlineTask<>> vec;
+        vec.push_back(task(count));
+        vec.push_back(task(count));
+        vec.push_back(task(count));
+
+        co_await tinycoro::InlineAwait(vec);
+        co_return;
+    };
+
+    tinycoro::RunInline(wrapper());
+
+    EXPECT_EQ(3, count);
+}
+
+TEST(InlineAwaitTest, InlineAwaitTest_coawait_container_exception)
+{
+    auto task = [](int32_t val) -> tinycoro::InlineTask<int32_t> {
+        throw std::runtime_error{"error"};
+        co_return val;
+    };
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<int32_t> {
+        std::vector<tinycoro::InlineTask<int32_t>> vec;
+        vec.push_back(task(40));
+        vec.push_back(task(41));
+        vec.push_back(task(42));
+
+        auto res = co_await tinycoro::InlineAwait(vec);
+        co_return res[0].value() + res[1].value() + res[2].value();
+    };
+
+    auto func = [&] { std::ignore = tinycoro::RunInline(wrapper()); };
+    EXPECT_THROW(func(), std::runtime_error);
+}
+
+TEST(AnyOfInlineAwaitTest, AnyOfInlineAwaitTest)
+{
+    auto task = [](int32_t val) -> tinycoro::InlineTask<int32_t> { co_return val; };
+
+    auto awaiter = tinycoro::AnyOfInlineAwait(task(42));
+    EXPECT_TRUE(awaiter.await_ready());
+    EXPECT_FALSE(awaiter.await_suspend(int32_t{}));
+
+    auto res = awaiter.await_resume();
+    EXPECT_EQ(res, 42);
+}
+
+TEST(AnyOfInlineAwaitTest, AnyOfInlineAwaitTest_stop_source)
+{
+    std::stop_source ss;
+    auto             task = [](int32_t val) -> tinycoro::InlineTask<int32_t> { co_return val; };
+
+    auto awaiter = tinycoro::AnyOfInlineAwait(ss, task(40), task(41), task(42));
+    EXPECT_TRUE(awaiter.await_ready());
+    EXPECT_FALSE(awaiter.await_suspend(int32_t{}));
+
+    auto [r1, r2, r3] = awaiter.await_resume();
+    EXPECT_EQ(r1, 40);
+    EXPECT_FALSE(r2.has_value());
+    EXPECT_FALSE(r3.has_value());
+}
+
+TEST(AnyOfInlineAwaitTest, AnyOfInlineAwaitTest_stop_source_container)
+{
+    std::stop_source ss;
+    auto             task = [](int32_t val) -> tinycoro::InlineTask<int32_t> { co_return val; };
+
+    std::vector<tinycoro::InlineTask<int32_t>> vec;
+    vec.push_back(task(40));
+    vec.push_back(task(41));
+    vec.push_back(task(42));
+
+    auto awaiter = tinycoro::AnyOfInlineAwait(ss, vec);
+    EXPECT_TRUE(awaiter.await_ready());
+    EXPECT_FALSE(awaiter.await_suspend(int32_t{}));
+
+    auto res = awaiter.await_resume();
+    EXPECT_EQ(res[0], 40);
+    EXPECT_FALSE(res[1].has_value());
+    EXPECT_FALSE(res[2].has_value());
+}
+
+TEST(AnyOfInlineAwaitTest, AnyOfInlineAwaitTest_functional_test)
+{
+    auto task = [](int32_t val) -> tinycoro::InlineTask<int32_t> { co_return val; };
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<> {
+        auto [r1, r2, r3] = co_await tinycoro::AnyOfInlineAwait(task(40), task(41), task(42));
+
+        EXPECT_EQ(r1, 40);
+        EXPECT_FALSE(r2.has_value());
+        EXPECT_FALSE(r3.has_value());
+
+        co_return;
+    };
+
+    tinycoro::RunInline(wrapper());
+}
+
+TEST(AnyOfInlineAwaitTest, AnyOfInlineAwaitTest_functional_test_stopSource)
+{
+    std::stop_source stopSource{};
+
+    auto task = [&stopSource](int32_t val) -> tinycoro::InlineTask<int32_t> {
+        auto ss = co_await tinycoro::this_coro::stop_source();
+        ss.request_stop();
+
+        EXPECT_EQ(ss, stopSource);
+
+        co_return val;
+    };
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<> {
+        auto [r1, r2, r3] = co_await tinycoro::AnyOfInlineAwait(stopSource, task(40), task(41), task(42));
+
+        EXPECT_EQ(r1, 40);
+        EXPECT_FALSE(r2.has_value());
+        EXPECT_FALSE(r3.has_value());
+
+        co_return;
+    };
+
+    tinycoro::RunInline(wrapper());
+}
+
+TEST(AnyOfInlineAwaitTest, AnyOfInlineAwaitTest_functional_test_stopSource_vector)
+{
+    std::stop_source stopSource{};
+
+    auto task = [&stopSource](int32_t val) -> tinycoro::InlineTask<int32_t> {
+        auto ss = co_await tinycoro::this_coro::stop_source();
+        ss.request_stop();
+
+        EXPECT_EQ(ss, stopSource);
+
+        co_return val;
+    };
+
+    std::vector<tinycoro::InlineTask<int32_t>> tasks;
+    tasks.push_back(task(42));
+    tasks.push_back(task(2));
+    tasks.push_back(task(3));
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<> {
+        auto res = co_await tinycoro::AnyOfInlineAwait(stopSource, tasks);
+
+        EXPECT_EQ(res[0], 42);
+        EXPECT_FALSE(res[1].has_value());
+        EXPECT_FALSE(res[2].has_value());
+    };
+
+    tinycoro::RunInline(wrapper());
+}
+
+TEST(AnyOfInlineAwaitTest, AnyOfInlineAwaitTest_functional_test_InlineNIC)
+{
+    std::stop_source stopSource{};
+
+    auto task = [&stopSource](int32_t val) -> tinycoro::InlineTaskNIC<int32_t> {
+        auto ss = co_await tinycoro::this_coro::stop_source();
+        EXPECT_EQ(ss, stopSource);
+
+        co_return val;
+    };
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<> {
+        // those tasks are not initial cancellable.
+        // So they will just simply return
+        auto [r1, r2, r3] = co_await tinycoro::AnyOfInlineAwait(stopSource, task(40), task(41), task(42));
+
+        EXPECT_EQ(r1, 40);
+        EXPECT_EQ(r2, 41);
+        EXPECT_EQ(r3, 42);
+    };
+
+    tinycoro::RunInline(wrapper());
+}
+
+TEST(AnyOfInlineAwaitTest, AnyOfInlineAwaitTest_functional_test_InlineNIC_vector)
+{
+    std::stop_source stopSource{};
+
+    auto task = [&stopSource](int32_t val) -> tinycoro::InlineTaskNIC<int32_t> {
+        auto ss = co_await tinycoro::this_coro::stop_source();
+        EXPECT_EQ(ss, stopSource);
+
+        co_return val;
+    };
+
+    std::vector<tinycoro::InlineTaskNIC<int32_t>> tasks;
+    tasks.push_back(task(40));
+    tasks.push_back(task(41));
+    tasks.push_back(task(42));
+
+    auto wrapper = [&]() -> tinycoro::InlineTask<> {
+        // those tasks are not initial cancellable.
+        // So they will just simply return
+        auto res = co_await tinycoro::AnyOfInlineAwait(stopSource, tasks);
+
+        EXPECT_EQ(res[0], 40);
+        EXPECT_EQ(res[1], 41);
+        EXPECT_EQ(res[2], 42);
+    };
+
+    tinycoro::RunInline(wrapper());
+}

--- a/test/src/Latch_test.cpp
+++ b/test/src/Latch_test.cpp
@@ -197,17 +197,17 @@ TEST_P(LatchTest, LatchFunctionalTest_Wait_cancel)
     tinycoro::SoftClock clock;
     tinycoro::Latch     latch{count};
 
-    auto task = [&]() -> tinycoro::Task<int32_t, LatchTest::Allocator> {
+    auto task = [&]() -> tinycoro::TaskNIC<int32_t, LatchTest::Allocator> {
         co_await tinycoro::Cancellable(latch.Wait());
         co_return 42;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<int32_t, LatchTest::Allocator> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<int32_t, LatchTest::Allocator> {
         co_await tinycoro::SleepFor<LatchTest::Allocator>(clock, 100ms);
         co_return 44;
     };
 
-    std::vector<tinycoro::Task<int32_t, LatchTest::Allocator>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t, LatchTest::Allocator>> tasks;
     tasks.reserve(count + 1);
     tasks.emplace_back(sleep());
     for (size_t i = 0; i < count; ++i)
@@ -306,21 +306,21 @@ TEST_P(LatchTest, LatchTest_cancel_multi)
 
     std::atomic<size_t> taskCount;
 
-    auto task1 = [&]() -> tinycoro::Task<size_t, LatchTest::Allocator> {
+    auto task1 = [&]() -> tinycoro::TaskNIC<size_t, LatchTest::Allocator> {
         co_await tinycoro::Cancellable(latch.Wait());
         co_return ++taskCount;
     };
-    auto task2 = [&]() -> tinycoro::Task<size_t, LatchTest::Allocator> {
+    auto task2 = [&]() -> tinycoro::TaskNIC<size_t, LatchTest::Allocator> {
         co_await tinycoro::Cancellable(latch.ArriveAndWait());
         co_return ++taskCount;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<size_t, LatchTest::Allocator> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<size_t, LatchTest::Allocator> {
         co_await tinycoro::SleepFor<LatchTest::Allocator>(clock, 50ms);
         co_return 44u;
     };
 
-    std::vector<tinycoro::Task<size_t, LatchTest::Allocator>> tasks;
+    std::vector<tinycoro::TaskNIC<size_t, LatchTest::Allocator>> tasks;
     tasks.reserve((count * 3) + 1);
     tasks.emplace_back(sleep());
     for (size_t i = 0; i < count; ++i)

--- a/test/src/ManualEvent_test.cpp
+++ b/test/src/ManualEvent_test.cpp
@@ -209,17 +209,17 @@ TEST_P(ManualEventTest, ManualEventTest_cancel)
 
     tinycoro::ManualEvent event;
 
-    auto task = [&]() -> tinycoro::Task<int32_t> {
+    auto task = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(event.Wait());
         co_return 42;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<int32_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::SleepFor(clock, 100ms);
         co_return 44;
     };
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t>> tasks;
     tasks.reserve(count + 1);
     tasks.emplace_back(sleep());
     for (size_t i = 0; i < count; ++i)
@@ -248,7 +248,7 @@ TEST_P(ManualEventTest, ManualEventTest_set_reset_cancel_custom_cache_size)
 
     std::atomic<size_t> taskCount{};
 
-    auto task = [&]() -> tinycoro::Task<int32_t> {
+    auto task = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(event.Wait());
         event.Reset();
 
@@ -260,12 +260,12 @@ TEST_P(ManualEventTest, ManualEventTest_set_reset_cancel_custom_cache_size)
         co_return 42;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<int32_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::SleepFor(clock, 100ms);
         co_return 44;
     };
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t>> tasks;
     tasks.reserve(count + 1);
     tasks.emplace_back(sleep());
     for (size_t i = 0; i < count; ++i)
@@ -293,7 +293,7 @@ TEST_P(ManualEventTest, ManualEventTest_set_reset_cancel_inline)
 
     std::atomic<size_t> taskCount{};
 
-    auto task = [&]() -> tinycoro::Task<int32_t> {
+    auto task = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(event.Wait());
         event.Reset();
 
@@ -305,12 +305,12 @@ TEST_P(ManualEventTest, ManualEventTest_set_reset_cancel_inline)
         co_return 42;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<int32_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::SleepFor(clock, 100ms);
         co_return 44;
     };
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t>> tasks;
     tasks.reserve(count + 1);
     tasks.emplace_back(sleep());
     for (size_t i = 0; i < count; ++i)

--- a/test/src/PauseHandler_test.cpp
+++ b/test/src/PauseHandler_test.cpp
@@ -100,7 +100,9 @@ TEST(PauseHandlerTest, PauseHandlerTest_pause)
     EXPECT_TRUE((std::same_as<decltype(func), decltype(res)>));
 
     EXPECT_TRUE(pauseHandler.IsPaused());
-    EXPECT_FALSE(pauseHandler.IsCancellable());
+
+    // initial cancellable as default
+    EXPECT_TRUE(pauseHandler.IsCancellable());
 
     pauseHandler.Unpause();
     EXPECT_FALSE(pauseHandler.IsPaused());
@@ -111,7 +113,22 @@ TEST(PauseHandlerTest, PauseHandlerTest_pause)
 TEST(PauseHandlerTest, PauseHandlerTest_MakeCancellable)
 {
     tinycoro::PauseHandler pauseHandler{[]{}};
+    
+    // initial cancellable as default
+    EXPECT_TRUE(pauseHandler.IsCancellable());
 
+    pauseHandler.SetCancellable(false);
+    EXPECT_FALSE(pauseHandler.IsCancellable());
+
+    pauseHandler.SetCancellable(true);
+    EXPECT_TRUE(pauseHandler.IsCancellable());
+}
+
+TEST(PauseHandlerTest, PauseHandlerTest_MakeCancellable_noninitial_cancellable)
+{
+    tinycoro::PauseHandler pauseHandler{[]{}, tinycoro::noninitial_cancellable_t::value};
+    
+    // initial cancellable as default
     EXPECT_FALSE(pauseHandler.IsCancellable());
 
     pauseHandler.SetCancellable(true);

--- a/test/src/Promsie_test.cpp
+++ b/test/src/Promsie_test.cpp
@@ -73,7 +73,7 @@ struct FinalAwaiterMock
 
 TEST(PromiseTest, PromiseTest_FinalAwaiter)
 {
-    tinycoro::detail::PromiseT<FinalAwaiterMock, tinycoro::detail::PromiseReturnValue<int32_t, FinalAwaiterMock>, tinycoro::PauseHandler, std::stop_source, tinycoro::detail::NonAllocatorAdapter> promise;
+    tinycoro::detail::PromiseT<FinalAwaiterMock, tinycoro::detail::PromiseReturnValue<int32_t, FinalAwaiterMock>, tinycoro::PauseHandler, std::stop_source, tinycoro::DefaultAllocator> promise;
     EXPECT_TRUE(requires { promise.return_value(42); });
     EXPECT_TRUE(requires { typename decltype(promise)::value_type; });
 
@@ -89,7 +89,7 @@ TEST(PromiseTest, PromiseTest_FinalAwaiter)
 
 TEST(PromiseTest, PromiseTest_YieldValue)
 {
-    tinycoro::detail::PromiseT<FinalAwaiterMock, tinycoro::detail::PromiseReturnValue<int32_t, FinalAwaiterMock>, tinycoro::PauseHandler, std::stop_source, tinycoro::detail::NonAllocatorAdapter> promise;
+    tinycoro::detail::PromiseT<FinalAwaiterMock, tinycoro::detail::PromiseReturnValue<int32_t, FinalAwaiterMock>, tinycoro::PauseHandler, std::stop_source, tinycoro::DefaultAllocator> promise;
     EXPECT_TRUE(requires { promise.return_value(42); });
     EXPECT_TRUE(requires { promise.yield_value(42); });
     EXPECT_TRUE(requires { typename decltype(promise)::value_type; });

--- a/test/src/RunInline_test.cpp
+++ b/test/src/RunInline_test.cpp
@@ -635,7 +635,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_pauseTask_stoped)
     auto consumer3 = [&]()->tinycoro::Task<>
     {
         // this task should be stopped through stopsource
-        co_await tinycoro::CancellableSuspend{};
+        co_await tinycoro::this_coro::yield_cancellable();
 
         // This code should never reached...
         i++; 
@@ -766,7 +766,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled)
 
     tinycoro::AutoEvent event;
 
-    auto waitTask = [&]() -> tinycoro::Task<int32_t> {
+    auto waitTask = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(event.Wait());
         co_return 42;
     };
@@ -795,7 +795,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled_latch)
 
     tinycoro::Latch latch{1};
 
-    auto waitTask = [&]() -> tinycoro::Task<int32_t> {
+    auto waitTask = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(latch.Wait());
         co_return 42;
     };
@@ -821,17 +821,17 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled_dynamic)
     tinycoro::SoftClock clock;
     tinycoro::AutoEvent event;
 
-    auto waitTask = [&]() -> tinycoro::Task<int32_t> {
+    auto waitTask = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(event.Wait());
         co_return 42;
     };
 
-    auto sleepTask = [&]() -> tinycoro::Task<int32_t> {
+    auto sleepTask = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::SleepFor(clock, 100ms);
         co_return 44;
     };
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t>> tasks;
     for(size_t i = 0; i < 5; ++i)
     {
         tasks.emplace_back(waitTask());
@@ -859,7 +859,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled_manual)
 
     tinycoro::ManualEvent event;
 
-    auto waitTask = [&]() -> tinycoro::Task<int32_t> {
+    auto waitTask = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::Cancellable(event.Wait());
         co_return 42;
     };

--- a/test/src/Scheduler_test.cpp
+++ b/test/src/Scheduler_test.cpp
@@ -53,7 +53,7 @@ TEST_P(SchedulerFunctionalTest, SchedulerFunctionalTest_full_queue_cache_task)
     auto task = [&](auto duration) -> tinycoro::Task<void> {
         for (auto start = std::chrono::system_clock::now(); std::chrono::system_clock::now() - start < duration;)
         {
-            co_await tinycoro::CancellableSuspend{};
+            co_await tinycoro::this_coro::yield_cancellable();
         }
         cc++;
     };

--- a/test/src/SingleEvent_test.cpp
+++ b/test/src/SingleEvent_test.cpp
@@ -193,10 +193,10 @@ TEST(SingleEventTest, SingleEventTest_cancel)
 
     tinycoro::SingleEvent<int32_t> event;
 
-    auto receiver = [&]() -> tinycoro::Task<int32_t> {
+    auto receiver = [&]() -> tinycoro::TaskNIC<int32_t> {
         auto result = co_await tinycoro::Cancellable(event.Wait());
         co_return result;
-    };
+    }; 
 
     auto [r1, r2] = tinycoro::AnyOf(scheduler, receiver(), tinycoro::SleepFor(clock, 100ms));
 
@@ -210,7 +210,7 @@ TEST(SingleEventTest, SingleEventTest_cancel_inline)
 
     tinycoro::SingleEvent<int32_t> event;
 
-    auto receiver = [&]() -> tinycoro::Task<int32_t> {
+    auto receiver = [&]() -> tinycoro::TaskNIC<int32_t> {
         auto result = co_await tinycoro::Cancellable(event.Wait());
         co_return result;
     };

--- a/test/src/Task_test.cpp
+++ b/test/src/Task_test.cpp
@@ -47,7 +47,7 @@ TEST(TaskTest, TaskTest_int)
 
 struct PauseHandlerMock
 {
-    PauseHandlerMock(auto cb)
+    PauseHandlerMock(auto cb, bool)
     : pauseResume{cb}
     {
     }
@@ -113,7 +113,7 @@ public:
 
 TEST(CoroTaskTest, CoroTaskTest)
 {
-    auto task = []()->tinycoro::detail::CoroTask<void, PromiseMock, PopAwaiterMock, CoroResumerMock> { co_return; }();
+    auto task = []()->tinycoro::detail::CoroTask<void, tinycoro::default_initial_cancellable_policy, PromiseMock, PopAwaiterMock, CoroResumerMock> { co_return; }();
 
     EXPECT_NO_THROW(task.SetStopSource(std::stop_source{}));
 

--- a/test/src/UnbufferedChannel_test.cpp
+++ b/test/src/UnbufferedChannel_test.cpp
@@ -445,13 +445,13 @@ TEST(UnbufferedChannelTest, UnbufferedChannelTest_cancel)
     tinycoro::SoftClock                  clock;
     tinycoro::UnbufferedChannel<int32_t> channel;
 
-    auto listener = [&]() -> tinycoro::Task<int32_t> {
+    auto listener = [&]() -> tinycoro::TaskNIC<int32_t> {
         int32_t val;
         co_await tinycoro::Cancellable(channel.PopWait(val));
         co_return 42;
     };
 
-    auto listenerWaiter = [&]() -> tinycoro::Task<void> { co_await tinycoro::Cancellable(channel.WaitForListeners(10)); };
+    auto listenerWaiter = [&]() -> tinycoro::TaskNIC<void> { co_await tinycoro::Cancellable(channel.WaitForListeners(10)); };
 
     auto [r1, r2, r3, r4, r5, r6, r7, r8, r9] = tinycoro::AnyOf(scheduler,
                                                                 listener(),
@@ -480,13 +480,13 @@ TEST(UnbufferedChannelTest, UnbufferedChannelTest_cancel_inline)
     tinycoro::SoftClock                  clock;
     tinycoro::UnbufferedChannel<int32_t> channel;
 
-    auto listener = [&]() -> tinycoro::Task<int32_t> {
+    auto listener = [&]() -> tinycoro::TaskNIC<int32_t> {
         int32_t val;
         co_await tinycoro::Cancellable(channel.PopWait(val));
         co_return 42;
     };
 
-    auto listenerWaiter = [&]() -> tinycoro::Task<void> { co_await tinycoro::Cancellable(channel.WaitForListeners(10)); };
+    auto listenerWaiter = [&]() -> tinycoro::TaskNIC<void> { co_await tinycoro::Cancellable(channel.WaitForListeners(10)); };
 
     auto [r1, r2, r3, r4, r5, r6, r7, r8, r9] = tinycoro::AnyOfInline(listener(),
                                                                       listener(),
@@ -874,17 +874,17 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_PushWait_cancel)
     const auto                          count = GetParam();
     tinycoro::UnbufferedChannel<size_t> channel;
 
-    auto task = [&]() -> tinycoro::Task<int32_t> {
+    auto task = [&]() -> tinycoro::TaskNIC<int32_t> {
         [[maybe_unused]] auto state = co_await tinycoro::Cancellable(channel.PushWait(42u));
         co_return 42;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<int32_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::SleepFor(clock, 100ms);
         co_return 44;
     };
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t>> tasks;
     tasks.reserve(count + 1);
     tasks.emplace_back(sleep());
     for ([[maybe_unused]] auto _ : std::views::iota(0u, count))
@@ -910,18 +910,18 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_PopWait_cancel)
     const auto                          count = GetParam();
     tinycoro::UnbufferedChannel<size_t> channel;
 
-    auto task = [&]() -> tinycoro::Task<int32_t> {
+    auto task = [&]() -> tinycoro::TaskNIC<int32_t> {
         size_t                val{};
         [[maybe_unused]] auto state = co_await tinycoro::Cancellable(channel.PopWait(val));
         co_return 42;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<int32_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<int32_t> {
         co_await tinycoro::SleepFor(clock, 100ms);
         co_return 44;
     };
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<int32_t>> tasks;
     tasks.reserve(count + 1);
     tasks.emplace_back(sleep());
     for ([[maybe_unused]] auto _ : std::views::iota(0u, count))
@@ -947,23 +947,23 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_Push_and_Pop_Wait_cancel)
     const auto                        count = GetParam();
     tinycoro::UnbufferedChannel<size_t> channel;
 
-    auto producer = [&](auto i) -> tinycoro::Task<size_t> {
-        [[maybe_unused]] auto state = co_await tinycoro::Cancellable(channel.PushWait(42u));
+    auto producer = [&](auto i) -> tinycoro::TaskNIC<size_t> {
+        [[maybe_unused]] auto state = co_await tinycoro::Cancellable{channel.PushWait(42u)};
         co_return i;
     };
 
-    auto consumer = [&]() -> tinycoro::Task<size_t> {
+    auto consumer = [&]() -> tinycoro::TaskNIC<size_t> {
         size_t val;
-        [[maybe_unused]] auto state = co_await tinycoro::Cancellable(channel.PopWait(val));
+        [[maybe_unused]] auto state = co_await tinycoro::Cancellable{channel.PopWait(val)};
         co_return val;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<size_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<size_t> {
         co_await tinycoro::SleepFor(clock, 50ms);
         co_return 44u;
     };
 
-    std::vector<tinycoro::Task<size_t>> tasks;
+    std::vector<tinycoro::TaskNIC<size_t>> tasks;
     tasks.reserve(count + 1);
     tasks.emplace_back(sleep());
     for ([[maybe_unused]] auto it : std::views::iota(0u, count))
@@ -984,23 +984,23 @@ TEST_P(UnbufferedChannelTest,UnbufferedChannelTest_Push_and_Pop_Wait_cancel_inli
     const auto                        count = GetParam();
     tinycoro::UnbufferedChannel<size_t> channel;
 
-    auto producer = [&](auto i) -> tinycoro::Task<size_t> {
+    auto producer = [&](auto i) -> tinycoro::TaskNIC<size_t> {
         [[maybe_unused]] auto state = co_await tinycoro::Cancellable(channel.PushWait(42u));
         co_return i;
     };
 
-    auto consumer = [&]() -> tinycoro::Task<size_t> {
+    auto consumer = [&]() -> tinycoro::TaskNIC<size_t> {
         size_t val;
         [[maybe_unused]] auto state = co_await tinycoro::Cancellable(channel.PopWait(val));
         co_return val;
     };
 
-    auto sleep = [&]() -> tinycoro::Task<size_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<size_t> {
         co_await tinycoro::SleepFor(clock, 50ms);
         co_return 44u;
     };
 
-    std::vector<tinycoro::Task<size_t>> tasks;
+    std::vector<tinycoro::TaskNIC<size_t>> tasks;
     tasks.reserve(count + 1);
     tasks.emplace_back(sleep());
     for ([[maybe_unused]] auto it : std::views::iota(0u, count))
@@ -1022,14 +1022,17 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_ListenerWait_cancel)
     const auto                          count = GetParam();
     tinycoro::UnbufferedChannel<size_t> channel;
 
-    auto task = [&]() -> tinycoro::Task<int32_t> { co_await tinycoro::Cancellable(channel.WaitForListeners(count + 1)); co_return 42; };
+    auto task = [&]() -> tinycoro::TaskNIC<size_t> { 
+        co_await tinycoro::Cancellable(channel.WaitForListeners(count + 1));
+        co_return 42;
+    };
 
-    auto sleep = [&]() -> tinycoro::Task<int32_t> {
+    auto sleep = [&]() -> tinycoro::TaskNIC<size_t> {
         co_await tinycoro::SleepFor(clock, 100ms);
         co_return 44;
     };
 
-    std::vector<tinycoro::Task<int32_t>> tasks;
+    std::vector<tinycoro::TaskNIC<size_t>> tasks;
     tasks.reserve(count + 1);
     tasks.emplace_back(sleep());
     for ([[maybe_unused]] auto _ : std::views::iota(0u, count))

--- a/test/src/mock/CoroutineHandleMock.h
+++ b/test/src/mock/CoroutineHandleMock.h
@@ -33,19 +33,19 @@ namespace tinycoro { namespace test {
         std::shared_ptr<PromiseT> _promise;
     };
 
-    template<typename T = void>
+    template<typename T = void, typename InitialCancellablePolicyT = tinycoro::noninitial_cancellable_t>
     auto MakeCoroutineHdl(std::regular_invocable auto pauseResumerCallback)
     {
         tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<T>> hdl;
-        hdl.promise().pauseHandler.emplace(pauseResumerCallback);
+        hdl.promise().pauseHandler.emplace(pauseResumerCallback, InitialCancellablePolicyT::value);
         return hdl;
     }
 
-    template<typename T = void>
+    template<typename T = void, typename InitialCancellablePolicyT = tinycoro::noninitial_cancellable_t>
     auto MakeCoroutineHdl()
     {
         tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<T>> hdl;
-        hdl.promise().pauseHandler.emplace([]{});
+        hdl.promise().pauseHandler.emplace([]{}, InitialCancellablePolicyT::value);
         return hdl;
     }
 


### PR DESCRIPTION
Introduce InlineAwait and AnyOfInlineAwait awaitables for inline coroutine execution
This PR adds support for inline coroutine execution via new awaitables: InlineAwait and AnyOfInlineAwait. These constructs allow users to seamlessly await RunInline(...)-style coroutine execution directly within a coroutine using co_await.

Key Additions
New awaitables in InlineAwait.hpp:

tinycoro::InlineAwait(...): Executes one or more tasks (or an iterable of tasks) inline and returns their result.

tinycoro::AnyOfInlineAwait(...): Executes one or more tasks inline and returns as soon as any of them completes, optionally supporting a std::stop_source for cancellation.

Helper concepts and deduction guides for seamless usage with containers, multiple tasks, and cancellation tokens.

Cancellable yield support added to this_coro namespace:

co_await this_coro::yield(); — non-cancellable

co_await this_coro::yield_cancellable(); — explicitly cancellable

Improved documentation in README.md, including:

How to disable initial cancellation

Clear guidance on how to use Cancellable{} to mark cancellable suspension points

Introduction of NIC type aliases for ease of use

Minor refactors in Common.hpp to support concepts and initial cancellation policy types.

Motivation
This change improves expressiveness and ergonomics when working with inline coroutine patterns by allowing a clean and composable co_await InlineAwait(...) syntax. It complements the existing RunInline(...) utility by making it available as a first-class coroutine awaitable.

