### PR TITLE
Dev/api cleanup stop source and sync

### DIFF
--- a/example/AggregateValue_example.h
+++ b/example/AggregateValue_example.h
@@ -21,7 +21,7 @@ void Example_aggregateValue(auto& scheduler)
         co_return Aggregate{42, 43};
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
 
     SyncOut() << "co_return => " << val->i << " " << val->j << '\n';
 }

--- a/example/AllOfAwait_example.h
+++ b/example/AllOfAwait_example.h
@@ -5,7 +5,7 @@
 
 #include <tinycoro/tinycoro_all.h>
 
-tinycoro::Task<std::string> Example_SyncAwait(auto& scheduler)
+tinycoro::Task<std::string> Example_AllOfAwait(auto& scheduler)
 {
     auto task1 = []() -> tinycoro::Task<std::string> { co_return "123"; };
     auto task2 = []() -> tinycoro::Task<std::string> { co_return "456"; };

--- a/example/AnyOfDynamicVoid_example.h
+++ b/example/AnyOfDynamicVoid_example.h
@@ -33,7 +33,7 @@ void Example_AnyOfDynamicVoid(auto& scheduler)
     tasks.push_back(task1(20ms));
     tasks.push_back(task1(30ms));
 
-    tinycoro::AnyOfWithStopSource(scheduler, source, std::move(tasks));
+    tinycoro::AnyOf(scheduler, source, std::move(tasks));
 
     SyncOut() << "co_return => void\n";
 }

--- a/example/AnyOfVoid_example.h
+++ b/example/AnyOfVoid_example.h
@@ -18,7 +18,7 @@ void Example_AnyOfVoid(auto& scheduler)
 
     std::stop_source source;
 
-    tinycoro::AnyOfWithStopSource(scheduler, source, task1(1s), task1(2s), task1(3s));
+    tinycoro::AnyOf(scheduler, source, task1(1s), task1(2s), task1(3s));
 
     SyncOut() << "co_return => void" << '\n';
 }

--- a/example/AsyncCallbackAwaiterCStyle_example.h
+++ b/example/AsyncCallbackAwaiterCStyle_example.h
@@ -29,7 +29,7 @@ void Example_asyncCallbackAwaiter_CStyle(auto& scheduler)
         co_return userData + res;
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
     SyncOut() << "co_return => " << *val << '\n';
 }
 

--- a/example/AsyncCallbackAwaiterReturnValue.h
+++ b/example/AsyncCallbackAwaiterReturnValue.h
@@ -36,7 +36,7 @@ void Example_asyncCallbackAwaiterWithReturnValue(auto& scheduler)
         co_return s.i;
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
     SyncOut() << "co_return => " << *val << '\n';
 }
 

--- a/example/AsyncCallbackAwaiter_example.h
+++ b/example/AsyncCallbackAwaiter_example.h
@@ -35,7 +35,7 @@ void Example_asyncCallbackAwaiter(auto& scheduler)
 
     try
     {
-        auto val = tinycoro::GetAll(scheduler, task());
+        auto val = tinycoro::AllOf(scheduler, task());
         SyncOut() << "co_return => " << *val << '\n';
     }
     catch (const std::exception& e)
@@ -43,7 +43,7 @@ void Example_asyncCallbackAwaiter(auto& scheduler)
         std::cerr << e.what() << '\n';
     }
 
-    // auto val = tinycoro::GetAll(scheduler, task());
+    // auto val = tinycoro::AllOf(scheduler, task());
     // SyncOut() << "co_return => " << *val << '\n';
 }
 

--- a/example/AsyncPulling_example.h
+++ b/example/AsyncPulling_example.h
@@ -38,7 +38,7 @@ void Example_asyncPulling(auto& scheduler)
         co_return val;
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
     SyncOut() << "co_return => " << *val << '\n';
 }
 

--- a/example/AutoEvent_example.h
+++ b/example/AutoEvent_example.h
@@ -26,7 +26,7 @@ void Example_AutoEvent(auto& scheduler)
     };
 
 
-    auto [result1, result2] = tinycoro::GetAll(scheduler, consumer(), producer());
+    auto [result1, result2] = tinycoro::AllOf(scheduler, consumer(), producer());
 
     assert(*result1 == 42);
 

--- a/example/BufferedChannel_example.h
+++ b/example/BufferedChannel_example.h
@@ -33,7 +33,7 @@ void Example_bufferedChannel(auto& scheduler)
     channel.Push(std::vector<int32_t>{7});
     channel.PushAndClose(std::vector<int32_t>{8, 9});   // push and close the channel
 
-    tinycoro::GetAll(scheduler, consumer());
+    tinycoro::AllOf(scheduler, consumer());
 }
 
 #endif //!__TINY_CORO_EXAMPLE_BUFFERED_CHANNEL_H__

--- a/example/CustomAwaiter.h
+++ b/example/CustomAwaiter.h
@@ -53,7 +53,7 @@ void Example_CustomAwaiter(auto& scheduler)
         co_return val;
     };
 
-    auto val = tinycoro::GetAll(scheduler, asyncTask());
+    auto val = tinycoro::AllOf(scheduler, asyncTask());
 
     SyncOut() << "co_return => " << *val << '\n'; 
 }

--- a/example/MoveOnlyValue_example.h
+++ b/example/MoveOnlyValue_example.h
@@ -28,7 +28,7 @@ void Example_moveOnlyValue(auto& scheduler)
         co_return 42;
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
 
     SyncOut() << "co_return => " << val->i << '\n';
 }

--- a/example/MultiMovedDynamicTasks_example.h
+++ b/example/MultiMovedDynamicTasks_example.h
@@ -31,9 +31,9 @@ void Example_multiMovedTasksDynamic(auto& scheduler)
     tasks.push_back(task2());
     tasks.push_back(task3());
 
-    auto results = tinycoro::GetAll(scheduler, std::move(tasks));
+    auto results = tinycoro::AllOf(scheduler, std::move(tasks));
 
-    SyncOut() << "GetAll co_return => " << *results[0] << ", " << *results[1] << ", " << *results[2] << '\n';
+    SyncOut() << "AllOf co_return => " << *results[0] << ", " << *results[1] << ", " << *results[2] << '\n';
 }
 
 #endif //!__TINY_CORO_EXAMPLE_MULTI_MOVED_TASKS_DYNAMIC_H__

--- a/example/MultiMovedTasksDynamicVoid_example.h
+++ b/example/MultiMovedTasksDynamicVoid_example.h
@@ -31,8 +31,7 @@ void Example_multiMovedTasksDynamicVoid(auto& scheduler)
     tasks.push_back(task2());
     tasks.push_back(task3());
 
-    auto futures = scheduler.Enqueue(std::move(tasks));
-    tinycoro::GetAll(futures);
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 #endif //!__TINY_CORO_EXAMPLE_MULTI_MOVED_TASKS_DYNAMIC_VOID_H__

--- a/example/MultiTaskDifferentValues_example.h
+++ b/example/MultiTaskDifferentValues_example.h
@@ -38,10 +38,10 @@ void Example_multiTaskDifferentValues(auto& scheduler)
     {
         auto [voidType, val, s] = tinycoro::AllOf(scheduler, task1(), task2(), task3());
 
-        SyncOut() << std::boolalpha << "GetAll task1 co_return => void " << std::is_same_v<std::optional<tinycoro::VoidType>, std::decay_t<decltype(voidType)>>
+        SyncOut() << std::boolalpha << "AllOf task1 co_return => void " << std::is_same_v<std::optional<tinycoro::VoidType>, std::decay_t<decltype(voidType)>>
                   << '\n';
-        SyncOut() << "GetAll task2 co_return => " << *val << '\n';
-        SyncOut() << "GetAll task3 co_return => " << (*s).i << '\n';
+        SyncOut() << "AllOf task2 co_return => " << *val << '\n';
+        SyncOut() << "AllOf task3 co_return => " << (*s).i << '\n';
     }
     catch (const std::exception& e)
     {

--- a/example/MultiTaskDifferentValues_example.h
+++ b/example/MultiTaskDifferentValues_example.h
@@ -36,7 +36,7 @@ void Example_multiTaskDifferentValues(auto& scheduler)
 
     try
     {
-        auto [voidType, val, s] = tinycoro::GetAll(scheduler, task1(), task2(), task3());
+        auto [voidType, val, s] = tinycoro::AllOf(scheduler, task1(), task2(), task3());
 
         SyncOut() << std::boolalpha << "GetAll task1 co_return => void " << std::is_same_v<std::optional<tinycoro::VoidType>, std::decay_t<decltype(voidType)>>
                   << '\n';

--- a/example/MultiTasksDynamic_example.h
+++ b/example/MultiTasksDynamic_example.h
@@ -31,7 +31,7 @@ void Example_multiTasksDynamic(auto& scheduler)
     tasks.push_back(task2());
     tasks.push_back(task3());
 
-    auto results = tinycoro::GetAll(scheduler, std::move(tasks));
+    auto results = tinycoro::AllOf(scheduler, std::move(tasks));
 
     SyncOut() << "GetAll co_return => " << *results[0] << ", " << *results[1] << ", " << *results[2] << '\n';
 }

--- a/example/MultiTasksDynamic_example.h
+++ b/example/MultiTasksDynamic_example.h
@@ -33,7 +33,7 @@ void Example_multiTasksDynamic(auto& scheduler)
 
     auto results = tinycoro::AllOf(scheduler, std::move(tasks));
 
-    SyncOut() << "GetAll co_return => " << *results[0] << ", " << *results[1] << ", " << *results[2] << '\n';
+    SyncOut() << "co_return => " << *results[0] << ", " << *results[1] << ", " << *results[2] << '\n';
 }
 
 #endif //!__TINY_CORO_EXAMPLE_MULTI_TASKS_DYNAMIC_H__

--- a/example/MultiTasks_example.h
+++ b/example/MultiTasks_example.h
@@ -16,7 +16,7 @@ void Example_multiTasks(auto& scheduler)
 
     tinycoro::AllOf(scheduler, task(), task(), task());
 
-    SyncOut() << "GetAll co_return => void" << '\n';
+    SyncOut() << "co_return => void" << '\n';
 }
 
 #endif //!__TINY_CORO_EXAMPLE_MULTI_TASKS_H__

--- a/example/MultiTasks_example.h
+++ b/example/MultiTasks_example.h
@@ -14,7 +14,7 @@ void Example_multiTasks(auto& scheduler)
         co_return;
     };
 
-    tinycoro::GetAll(scheduler, task(), task(), task());
+    tinycoro::AllOf(scheduler, task(), task(), task());
 
     SyncOut() << "GetAll co_return => void" << '\n';
 }

--- a/example/NestedTask_example.h
+++ b/example/NestedTask_example.h
@@ -22,7 +22,7 @@ void Example_nestedTask(auto& scheduler)
         co_return val;
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
 
     SyncOut() << "co_return => " << *val << '\n';
 }

--- a/example/ReturnValueTask_example.h
+++ b/example/ReturnValueTask_example.h
@@ -15,7 +15,7 @@ void Example_returnValueTask(auto& scheduler)
         co_return 42;
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
 
     SyncOut() << "co_return => " << *val << '\n';
 }

--- a/example/Semaphore_example.h
+++ b/example/Semaphore_example.h
@@ -14,7 +14,7 @@ void Example_Semaphore(tinycoro::Scheduler& scheduler)
         co_return ++count;
     };
 
-    auto [c1, c2, c3] = tinycoro::GetAll(scheduler, task(), task(), task());
+    auto [c1, c2, c3] = tinycoro::AllOf(scheduler, task(), task(), task());
 
     // Every varaible should have unique value (on intel processor for sure :) ).
     // So (c1 != c2 && c2 != c3 && c3 != c1)

--- a/example/Sleep_example.h
+++ b/example/Sleep_example.h
@@ -17,7 +17,7 @@ void Example_sleep(auto& scheduler)
         co_return 42;
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
 
     SyncOut() << "co_return => " << *val << '\n';
 }

--- a/example/SyncAwait_example.h
+++ b/example/SyncAwait_example.h
@@ -12,7 +12,7 @@ tinycoro::Task<std::string> Example_SyncAwait(auto& scheduler)
     auto task3 = []() -> tinycoro::Task<std::string> { co_return "789"; };
 
     // waiting to finish all other tasks. (non blocking)
-    auto tupleResult = co_await tinycoro::SyncAwait(scheduler, task1(), task2(), task3());
+    auto tupleResult = co_await tinycoro::AllOfAwait(scheduler, task1(), task2(), task3());
 
     // tuple accumulate
     co_return std::apply(

--- a/example/UsageWithStopToken_example.h
+++ b/example/UsageWithStopToken_example.h
@@ -38,7 +38,7 @@ void Example_usageWithStopToken(auto& scheduler)
 
     std::stop_source source;
 
-    auto results = tinycoro::GetAll(scheduler, task1(1s, source), task2(source.get_token()));
+    auto results = tinycoro::AllOf(scheduler, task1(1s, source), task2(source.get_token()));
 
     auto task2Val = std::get<1>(results);
 

--- a/example/VoidTask_example.h
+++ b/example/VoidTask_example.h
@@ -14,7 +14,7 @@ void Example_voidTask(auto& scheduler)
         co_return;
     };
 
-    tinycoro::GetAll(scheduler, task());
+    tinycoro::AllOf(scheduler, task());
 
     SyncOut() << "co_return => void" << '\n';
 }

--- a/example/echo_server_example/echo_server_main.cpp
+++ b/example/echo_server_example/echo_server_main.cpp
@@ -170,7 +170,7 @@ tinycoro::Task<void> EPoll(auto& newConnectionChannel, auto& receiveChannel, fil
 
         // run cleanup coroutine on the current thread
         // if we leave the coroutine task
-        tinycoro::RunInline(cleanUp()); 
+        tinycoro::AllOfInline(cleanUp()); 
     });
 
     // Create epoll instance

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -34,7 +34,7 @@
 #include "CustomAwaiter.h"
 
 #include "AnyOfCoAwait_example.h"
-#include "SyncAwait_example.h"
+#include "AllOfAwait_example.h"
 
 #include "Semaphore_example.h"
 
@@ -98,7 +98,7 @@ int main()
 
         Example_CustomAwaiter(scheduler);
 
-        auto val = tinycoro::AllOf(scheduler, Example_SyncAwait(scheduler));
+        auto val = tinycoro::AllOf(scheduler, Example_AllOfAwait(scheduler));
         SyncOut() << *val << '\n';
 
         scheduler.Enqueue(Example_AnyOfCoAwait(scheduler)).get();

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -98,7 +98,7 @@ int main()
 
         Example_CustomAwaiter(scheduler);
 
-        auto val = tinycoro::GetAll(scheduler, Example_SyncAwait(scheduler));
+        auto val = tinycoro::AllOf(scheduler, Example_SyncAwait(scheduler));
         SyncOut() << *val << '\n';
 
         scheduler.Enqueue(Example_AnyOfCoAwait(scheduler)).get();

--- a/include/tinycoro/PromiseBase.hpp
+++ b/include/tinycoro/PromiseBase.hpp
@@ -117,7 +117,7 @@ namespace tinycoro { namespace detail {
 
         // Sets the destroyer notifier callback
         //
-        // It is used in the "SyncAwait" like context.
+        // It is used in the "AllOfAwait" like context.
         template <std::regular_invocable T>
         void SetDestroyNotifier(T&& cb) noexcept
         {

--- a/include/tinycoro/WaitInline.hpp
+++ b/include/tinycoro/WaitInline.hpp
@@ -303,7 +303,7 @@ namespace tinycoro {
         using TaskReturnT = typename std::decay_t<ContainerT>::value_type::value_type;
 
         template <concepts::Iterable ContainerT, typename StopSourceT>
-        void RunInlineImplContainer(ContainerT&& container, StopSourceT stopSource)
+        void WaitInlineImplContainer(ContainerT&& container, StopSourceT stopSource)
         {
             std::exception_ptr     exception{};
             helper::AutoResetEvent event{};
@@ -414,7 +414,7 @@ namespace tinycoro {
     [[nodiscard]] auto AllOfInline(ContainerT&& container)
     {
         // Runs all the tasks sequentialy
-        detail::RunInlineImplContainer(container, std::stop_source{std::nostopstate});
+        detail::WaitInlineImplContainer(container, std::stop_source{std::nostopstate});
         return detail::CollectResults(container);
     }
 
@@ -423,7 +423,7 @@ namespace tinycoro {
     void AllOfInline(ContainerT&& container)
     {
         // Runs all the tasks sequentialy
-        detail::RunInlineImplContainer(container, std::stop_source{std::nostopstate});
+        detail::WaitInlineImplContainer(container, std::stop_source{std::nostopstate});
     }
 
     template <concepts::IsStopSource StopSourceT, concepts::Iterable ContainerT>
@@ -431,7 +431,7 @@ namespace tinycoro {
     [[nodiscard]] auto AnyOfInline(StopSourceT stopSource, ContainerT&& container)
     {
         // Runs all the tasks sequentialy
-        detail::RunInlineImplContainer(container, stopSource);
+        detail::WaitInlineImplContainer(container, stopSource);
         return detail::CollectResults(container);
     }
 
@@ -440,7 +440,7 @@ namespace tinycoro {
     void AnyOfInline(StopSourceT stopSource, ContainerT&& container)
     {
         // Runs all the tasks sequentialy
-        detail::RunInlineImplContainer(container, stopSource);
+        detail::WaitInlineImplContainer(container, stopSource);
     }
 
     template < concepts::IsStopSource StopSourceT = std::stop_source, concepts::Iterable ContainerT>

--- a/include/tinycoro/WaitInline.hpp
+++ b/include/tinycoro/WaitInline.hpp
@@ -3,8 +3,8 @@
 //  Licensed under the MIT License – see LICENSE.txt for details.
 // -----------------------------------------------------------------------------
 
-#ifndef TINY_CORO_RUN_INLINE_HPP
-#define TINY_CORO_RUN_INLINE_HPP
+#ifndef TINY_CORO_WAIT_INLINE_HPP
+#define TINY_CORO_WAIT_INLINE_HPP
 
 #include <type_traits>
 #include <atomic>
@@ -259,7 +259,7 @@ namespace tinycoro {
     // and you anyway want to wait for the result. (No need for a scheduler)
     template <typename... TaskT>
         requires (sizeof...(TaskT) > 0) && (!concepts::SameAsValueType<void, TaskT...>)
-    [[nodiscard]] auto RunInline(TaskT&&... tasks)
+    [[nodiscard]] auto AllOfInline(TaskT&&... tasks)
     {
         detail::InlineScheduler inlineScheduler{std::forward_as_tuple(tasks...)};
         return inlineScheduler.Run();
@@ -267,34 +267,34 @@ namespace tinycoro {
 
     template <typename... TaskT>
         requires (sizeof...(TaskT) > 0) && concepts::SameAsValueType<void, TaskT...>
-    void RunInline(TaskT&&... tasks)
+    void AllOfInline(TaskT&&... tasks)
     {
         detail::InlineScheduler inlineScheduler{std::forward_as_tuple(tasks...)};
         std::ignore = inlineScheduler.Run();
     }
 
-    template <typename StopSourceT = std::stop_source, typename... TaskT>
+    template <concepts::IsStopSource StopSourceT = std::stop_source, typename... TaskT>
         requires (sizeof...(TaskT) > 0) && (!concepts::SameAsValueType<void, TaskT...>)
-    [[nodiscard]] auto AnyOfWithStopSourceInline(StopSourceT stopSource, TaskT&&... tasks)
+    [[nodiscard]] auto AnyOfInline(StopSourceT stopSource, TaskT&&... tasks)
     {
         detail::InlineScheduler inlineScheduler{stopSource, std::forward_as_tuple(tasks...)};
         return inlineScheduler.Run();
     }
 
-    template <typename StopSourceT = std::stop_source, typename... TaskT>
+    template <concepts::IsStopSource StopSourceT = std::stop_source, typename... TaskT>
         requires (sizeof...(TaskT) > 0) && concepts::SameAsValueType<void, TaskT...>
-    void AnyOfWithStopSourceInline(StopSourceT stopSource, TaskT&&... tasks)
+    void AnyOfInline(StopSourceT stopSource, TaskT&&... tasks)
     {
         detail::InlineScheduler inlineScheduler{stopSource, std::forward_as_tuple(tasks...)};
         std::ignore = inlineScheduler.Run();
     }
 
-    template <typename StopSourceT = std::stop_source, concepts::NonIterable... TaskT>
+    template <concepts::IsStopSource StopSourceT = std::stop_source, concepts::NonIterable... TaskT>
         requires (sizeof...(TaskT) > 0)
     [[nodiscard]] auto AnyOfInline(TaskT&&... tasks)
     {
         StopSourceT stopSource{};
-        return AnyOfWithStopSourceInline(stopSource, std::forward<TaskT>(tasks)...);
+        return AnyOfInline(stopSource, std::forward<TaskT>(tasks)...);
     }
 
     namespace detail {
@@ -411,7 +411,7 @@ namespace tinycoro {
 
     template <concepts::Iterable ContainerT>
         requires (!std::same_as<detail::TaskReturnT<ContainerT>, void>)
-    [[nodiscard]] auto RunInline(ContainerT&& container)
+    [[nodiscard]] auto AllOfInline(ContainerT&& container)
     {
         // Runs all the tasks sequentialy
         detail::RunInlineImplContainer(container, std::stop_source{std::nostopstate});
@@ -420,36 +420,36 @@ namespace tinycoro {
 
     template <concepts::Iterable ContainerT>
         requires std::same_as<detail::TaskReturnT<ContainerT>, void>
-    void RunInline(ContainerT&& container)
+    void AllOfInline(ContainerT&& container)
     {
         // Runs all the tasks sequentialy
         detail::RunInlineImplContainer(container, std::stop_source{std::nostopstate});
     }
 
-    template <concepts::Iterable ContainerT, typename StopSourceT>
+    template <concepts::IsStopSource StopSourceT, concepts::Iterable ContainerT>
         requires (!std::same_as<detail::TaskReturnT<ContainerT>, void>)
-    [[nodiscard]] auto AnyOfWithStopSourceInline(StopSourceT stopSource, ContainerT&& container)
+    [[nodiscard]] auto AnyOfInline(StopSourceT stopSource, ContainerT&& container)
     {
         // Runs all the tasks sequentialy
         detail::RunInlineImplContainer(container, stopSource);
         return detail::CollectResults(container);
     }
 
-    template <concepts::Iterable ContainerT, typename StopSourceT>
+    template <concepts::IsStopSource StopSourceT, concepts::Iterable ContainerT>
         requires std::same_as<detail::TaskReturnT<ContainerT>, void>
-    void AnyOfWithStopSourceInline(StopSourceT stopSource, ContainerT&& container)
+    void AnyOfInline(StopSourceT stopSource, ContainerT&& container)
     {
         // Runs all the tasks sequentialy
         detail::RunInlineImplContainer(container, stopSource);
     }
 
-    template <concepts::Iterable ContainerT, typename StopSourceT = std::stop_source>
+    template < concepts::IsStopSource StopSourceT = std::stop_source, concepts::Iterable ContainerT>
     [[nodiscard]] auto AnyOfInline(ContainerT&& container)
     {
         StopSourceT stopSource{};
-        return AnyOfWithStopSourceInline(stopSource, std::forward<ContainerT>(container));
+        return AnyOfInline(stopSource, std::forward<ContainerT>(container));
     }
 
 } // namespace tinycoro
 
-#endif // TINY_CORO_RUN_INLINE_HPP
+#endif // TINY_CORO_WAIT_INLINE_HPP

--- a/include/tinycoro/tinycoro_all.h
+++ b/include/tinycoro/tinycoro_all.h
@@ -17,8 +17,9 @@
 #include "StopSourceAwaiter.hpp"
 #include "SleepAwaiter.hpp"
 #include "Wait.hpp"
-#include "RunInline.hpp"
-#include "SyncAwait.hpp"
+#include "WaitInline.hpp"
+#include "CoWait.hpp"
+#include "CoWaitInline.hpp"
 #include "Semaphore.hpp"
 #include "SingleEvent.hpp"
 #include "Latch.hpp"
@@ -31,6 +32,5 @@
 #include "UnbufferedChannel.hpp"
 #include "SoftClock.hpp"
 #include "Cancellable.hpp"
-#include "InlineAwait.hpp"
 
 #endif // TINY_CORO_TINY_CORO_ALL_H

--- a/test/src/AllocatorAdapterTest.cpp
+++ b/test/src/AllocatorAdapterTest.cpp
@@ -47,7 +47,7 @@ struct AllocatorAdapterTest : testing::Test
     MockAllocatorTracer mock;
 };
 
-TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_RunInline)
+TEST_F(AllocatorAdapterTest, AllocatorAdapterTest_WaitInline)
 {
     EXPECT_CALL(mock, allocate_bytes_noexcept).Times(1).WillOnce([](size_t nbytes) { return std::malloc(nbytes); });
     EXPECT_CALL(mock, deallocate_bytes).Times(1).WillOnce([](void* p, [[maybe_unused]] size_t nbytes) { return std::free(p); });

--- a/test/src/AtomicPtrStack_test.cpp
+++ b/test/src/AtomicPtrStack_test.cpp
@@ -89,7 +89,7 @@ TEST_P(AtomicPtrStackFunctionalTest, AtomicPtrStackFunctionalTest_multi_threaded
         co_return;
     };
     
-    tinycoro::GetAll(scheduler, producer(vec1), producer(vec2), producer(vec3), producer(vec4));
+    tinycoro::AllOf(scheduler, producer(vec1), producer(vec2), producer(vec3), producer(vec4));
 
     auto elem = stack.close();
 

--- a/test/src/AtomicQueue_test.cpp
+++ b/test/src/AtomicQueue_test.cpp
@@ -139,7 +139,7 @@ TEST(AtomicQueueTest, AtomicQueueTest_wait_for_push)
         EXPECT_EQ(val, 3u);
     };
 
-    tinycoro::GetAll(scheduler, producer(), consumer());
+    tinycoro::AllOf(scheduler, producer(), consumer());
 }
 
 TEST(AtomicQueueTest, AtomicQueueTest_wait_for_pop)
@@ -187,7 +187,7 @@ TEST(AtomicQueueTest, AtomicQueueTest_wait_for_pop)
         EXPECT_EQ(val, 4u);
     };
 
-    tinycoro::GetAll(scheduler, producer(), consumer());
+    tinycoro::AllOf(scheduler, producer(), consumer());
 }
 
 struct AtomicQueueFunctionalTest : testing::TestWithParam<size_t>
@@ -241,7 +241,7 @@ TEST_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest_multi_threaded_pop)
     };
 
     auto [v1, v2, v3, v4, v5, v6, v7, v8]
-        = tinycoro::GetAll(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer());
+        = tinycoro::AllOf(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer());
 
     auto sum = *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *v7 + *v8;
 
@@ -266,7 +266,7 @@ TEST_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest_multi_threaded)
         co_return;
     };
 
-    tinycoro::GetAll(scheduler, producer(), producer(), producer(), producer(), producer(), producer(), producer(), producer());
+    tinycoro::AllOf(scheduler, producer(), producer(), producer(), producer(), producer(), producer(), producer(), producer());
 
     EXPECT_FALSE(queue.empty());
 
@@ -281,7 +281,7 @@ TEST_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest_multi_threaded)
     };
 
     auto [v1, v2, v3, v4, v5, v6, v7, v8]
-        = tinycoro::GetAll(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer());
+        = tinycoro::AllOf(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer());
 
     auto sum = *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *v7 + *v8;
 
@@ -328,7 +328,7 @@ TEST_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest_multi_threaded_toget
         co_return c;
     };
 
-    auto [v9, v10, v11, v12, v13, v14, v15, v16, v1, v2, v3, v4, v5, v6, v7, v8] = tinycoro::GetAll(scheduler,
+    auto [v9, v10, v11, v12, v13, v14, v15, v16, v1, v2, v3, v4, v5, v6, v7, v8] = tinycoro::AllOf(scheduler,
                                                                                                     producer(),
                                                                                                     producer(),
                                                                                                     producer(),
@@ -393,7 +393,7 @@ TEST_P(AtomicQueueFunctionalTest, AtomicQueueFunctionalTest_small_cache_test)
         co_return;
     };
 
-    tinycoro::GetAll(scheduler,
+    tinycoro::AllOf(scheduler,
                      producer(),
                      producer(),
                      producer(),

--- a/test/src/AutoEvent_test.cpp
+++ b/test/src/AutoEvent_test.cpp
@@ -146,7 +146,7 @@ TEST_P(AutoEventTest, AutoEventFunctionalTest)
     }
     tasks.push_back(autoEventProducer());
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 TEST_P(AutoEventTest, AutoEventFunctionalTest_preset)
@@ -171,7 +171,7 @@ TEST_P(AutoEventTest, AutoEventFunctionalTest_preset)
         tasks.push_back(autoEventConsumer());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     EXPECT_EQ(count, autoCount);
 }
@@ -345,7 +345,7 @@ TEST_P(AutoEventTest, AutoEventFunctionalTest_concurrentSetAndWait)
         tasks.push_back(task());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     // Since event is auto-resetting, each Set should trigger only one waiter
     EXPECT_EQ(counter, GetParam());
@@ -363,7 +363,7 @@ TEST(AutoEventTest, AutoEventFunctionalTest_setBeforeAwait)
         waited = true;
     };
 
-    tinycoro::GetAll(scheduler, task());
+    tinycoro::AllOf(scheduler, task());
 
     // Since the event was set before co_await, waited should be true
     EXPECT_TRUE(waited);
@@ -395,7 +395,7 @@ TEST_P(AutoEventStressTest, AutoEventStressTest_1)
     };
 
     // starting 8 async tasks at the same time
-    tinycoro::GetAll(scheduler, task(), task(), task(), task(), task(), task(), task(), task());
+    tinycoro::AllOf(scheduler, task(), task(), task(), task(), task(), task(), task(), task());
 
     EXPECT_EQ(count, size * 8);
 }

--- a/test/src/Barrier_test.cpp
+++ b/test/src/Barrier_test.cpp
@@ -319,7 +319,7 @@ TEST_P(BarrierTest, BarrierFunctionalTest_1)
         tasks.push_back(task());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     EXPECT_EQ(number, 0);
 }
@@ -364,7 +364,7 @@ TEST(BarrierTest, BarrierFunctionalTest_2)
         co_return name;
     };
 
-    auto [anil, busara, carl] = tinycoro::GetAll(scheduler, work(workers[0]), work(workers[1]), work(workers[2]));
+    auto [anil, busara, carl] = tinycoro::AllOf(scheduler, work(workers[0]), work(workers[1]), work(workers[2]));
 
     EXPECT_EQ(anil, workers[0]);
     EXPECT_EQ(busara, workers[1]);
@@ -423,7 +423,7 @@ TEST(BarrierTest, BarrierFewerTasksThanCount)
     };
 
     // Run all tasks
-    tinycoro::GetAll(scheduler, task(), task(), controlTask());
+    tinycoro::AllOf(scheduler, task(), task(), controlTask());
 
     EXPECT_EQ(number, 202);
     EXPECT_EQ(completion_count, 1);
@@ -467,7 +467,7 @@ TEST(BarrierTest, BarrierFewerTasksThanCount_withControlComplitionCallback)
     };
 
     // Run all tasks
-    tinycoro::GetAll(scheduler, task(), task());
+    tinycoro::AllOf(scheduler, task(), task());
 
     EXPECT_EQ(number, 202);
     EXPECT_EQ(completion_count, 1);
@@ -505,7 +505,7 @@ TEST_P(BarrierTest, BarrierTest_functionalTest_3)
         tasks.push_back(task());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 TEST(BarrierTest, BarrierTest_functionalTest_cancel_scheduler)
@@ -574,7 +574,7 @@ TEST(BarrierTest, BarrierTest_preset_stopSource_cancel)
     auto task2 = [&]() -> tinycoro::Task<void> { count++; co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
 
     stopSource.request_stop();
-    tinycoro::AnyOfWithStopSource(scheduler, stopSource, task2(), task1());
+    tinycoro::AnyOf(scheduler, stopSource, task2(), task1());
 
     // all the coroutines are cancelled before the execution.
     EXPECT_EQ(count, 0);
@@ -582,7 +582,7 @@ TEST(BarrierTest, BarrierTest_preset_stopSource_cancel)
     auto taskNic1 = [&]() -> tinycoro::TaskNIC<void> { count++; co_await tinycoro::Cancellable(barrier.Wait()); };
     auto taskNic2 = [&]() -> tinycoro::TaskNIC<void> { count++; co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
 
-    tinycoro::AnyOfWithStopSource(scheduler, stopSource, taskNic1(), taskNic2());
+    tinycoro::AnyOf(scheduler, stopSource, taskNic1(), taskNic2());
 
     // The tasks are not initiali cancellable
     // so they will run and increase the count variable.
@@ -602,14 +602,14 @@ TEST(BarrierTest, BarrierTest_preset_stopSource_inline)
     auto task2 = [&]() -> tinycoro::Task<void> { count++; co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
 
     stopSource.request_stop();
-    tinycoro::AnyOfWithStopSourceInline(stopSource, task2(), task1());
+    tinycoro::AnyOfInline(stopSource, task2(), task1());
 
     EXPECT_EQ(count, 0);
 
     auto taskNic1 = [&]() -> tinycoro::TaskNIC<void> { count++; co_await tinycoro::Cancellable(barrier.Wait()); };
     auto taskNic2 = [&]() -> tinycoro::TaskNIC<void> { count++; co_await tinycoro::Cancellable(barrier.ArriveAndWait()); };
 
-    tinycoro::AnyOfWithStopSourceInline(stopSource, taskNic2(), taskNic1());
+    tinycoro::AnyOfInline(stopSource, taskNic2(), taskNic1());
 
     EXPECT_EQ(count, 2);
 }
@@ -689,7 +689,7 @@ TEST_P(BarrierFunctionalTest, BarrierTest_functionalTest_4)
     }
     tasks.push_back(worker());
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 TEST(BarrierTest, BarrierTest_completionException)
@@ -707,6 +707,6 @@ TEST(BarrierTest, BarrierTest_completionException)
         fullyCompleted++;
     };
 
-    EXPECT_THROW(tinycoro::GetAll(scheduler, task(), task()), std::runtime_error);
+    EXPECT_THROW(tinycoro::AllOf(scheduler, task(), task()), std::runtime_error);
     EXPECT_EQ(fullyCompleted, 1);
 }

--- a/test/src/BoundTask_test.cpp
+++ b/test/src/BoundTask_test.cpp
@@ -91,7 +91,7 @@ TEST(BoundTaskTest, BoundTaskFunctionalTest_SingleBoundTask)
 
     auto coro = [&i]() -> tinycoro::Task<int32_t> { co_return i++; };
 
-    auto result = tinycoro::GetAll(scheduler, tinycoro::MakeBound(coro));
+    auto result = tinycoro::AllOf(scheduler, tinycoro::MakeBound(coro));
 
     EXPECT_EQ(result, 0);
     EXPECT_EQ(i, 1);
@@ -112,7 +112,7 @@ TEST(BoundTaskTest, BoundTaskFunctionalTest_coawait_task)
         co_return ++val;
     };
 
-    auto result = tinycoro::GetAll(scheduler, tinycoro::MakeBound(coro));
+    auto result = tinycoro::AllOf(scheduler, tinycoro::MakeBound(coro));
 
     EXPECT_EQ(result, 2);
     EXPECT_EQ(i, 1);
@@ -193,7 +193,7 @@ TEST_P(BoundTaskTest, BoundTaskFunctionalTest_MultiTasks)
         tasks.push_back(tinycoro::MakeBound(coro));
     }
 
-    auto results = tinycoro::GetAll(scheduler, std::move(tasks));
+    auto results = tinycoro::AllOf(scheduler, std::move(tasks));
 
     // check for unique values
     std::set<size_t> set;
@@ -232,7 +232,7 @@ TEST_P(BoundTaskTest, BoundTaskFunctionalTest_coawait_task_multi)
         tasks.push_back(tinycoro::MakeBound(coro));
     }
 
-    auto results = tinycoro::GetAll(scheduler, std::move(tasks));
+    auto results = tinycoro::AllOf(scheduler, std::move(tasks));
 
     // check for unique values
     std::set<size_t> set;

--- a/test/src/BufferedChannel_test.cpp
+++ b/test/src/BufferedChannel_test.cpp
@@ -584,7 +584,7 @@ TEST(BufferedChannelTest, BufferedChannelFunctionalTest_cleanup_callback_pushWai
         EXPECT_EQ(val, expected);
     };
 
-    tinycoro::RunInline(producer(40), producer(41), producer(42), producer(43), producer(44), consumer(40), consumer(41));
+    tinycoro::AllOfInline(producer(40), producer(41), producer(42), producer(43), producer(44), consumer(40), consumer(41));
 
     channel.Close();
 
@@ -617,7 +617,7 @@ TEST(BufferedChannelTest, BufferedChannelFunctionalTest_cleanup_callback_stuck_p
         co_return;
     };
 
-    tinycoro::RunInline(producer(40), producer(41), producer(42), producer(43), producer(44), consumer(40), consumer(41), closer());
+    tinycoro::AllOfInline(producer(40), producer(41), producer(42), producer(43), producer(44), consumer(40), consumer(41), closer());
 
     EXPECT_EQ(coll.size(), 3);
 
@@ -748,7 +748,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_waitForce)
 
     auto duration = 200ms;
 
-    tinycoro::GetAll(scheduler, producer(duration), consumer(duration));
+    tinycoro::AllOf(scheduler, producer(duration), consumer(duration));
 }
 
 TEST(BufferedChannelTest, BufferedChannelTest_push_await_order)
@@ -950,7 +950,7 @@ TEST(BufferedChannelTest, BufferedChannelFunctionalTest)
     // single threaded scheduler
     tinycoro::Scheduler scheduler{1};
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 }
 
 TEST(BufferedChannelTest, BufferedChannelFunctionalTest_pushWait_singleThreadedScheduler)
@@ -985,7 +985,7 @@ TEST(BufferedChannelTest, BufferedChannelFunctionalTest_pushWait_singleThreadedS
     // single threaded scheduler
     tinycoro::Scheduler scheduler{1};
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 }
 
 struct BufferedChannelTest : testing::TestWithParam<size_t>
@@ -1036,7 +1036,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_param)
         channel.Close();
     };
 
-    tinycoro::GetAll(scheduler, producer(), consumer());
+    tinycoro::AllOf(scheduler, producer(), consumer());
     EXPECT_EQ(allValues.size(), count);
 }
 
@@ -1076,7 +1076,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_param_pushWait)
         channel.Close();
     };
 
-    tinycoro::GetAll(scheduler, producer(), consumer());
+    tinycoro::AllOf(scheduler, producer(), consumer());
     EXPECT_EQ(allValues.size(), count);
 }
 
@@ -1120,7 +1120,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_paramMulti)
         channel.Close();
     };
 
-    tinycoro::GetAll(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer(), consumer());
+    tinycoro::AllOf(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer(), consumer());
 
     EXPECT_EQ(allValues.size(), count);
 }
@@ -1165,7 +1165,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_paramMulti_pushWait)
         channel.Close();
     };
 
-    tinycoro::GetAll(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer(), consumer());
+    tinycoro::AllOf(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer(), consumer());
 
     EXPECT_EQ(allValues.size(), count);
 }
@@ -1195,7 +1195,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_waitForListeners)
         tasks.push_back(consumer());
     }
 
-    EXPECT_NO_THROW(tinycoro::GetAll(scheduler, std::move(tasks)));
+    EXPECT_NO_THROW(tinycoro::AllOf(scheduler, std::move(tasks)));
 }
 
 TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_waitForListeners_multi_waiters)
@@ -1223,7 +1223,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_waitForListeners_multi
         tasks.push_back(producer());
     }
 
-    EXPECT_NO_THROW(tinycoro::GetAll(scheduler, std::move(tasks)));
+    EXPECT_NO_THROW(tinycoro::AllOf(scheduler, std::move(tasks)));
 }
 
 TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_waitForListenersClose)
@@ -1248,7 +1248,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_waitForListenersClose)
     }
     tasks.push_back(producer());
 
-    EXPECT_NO_THROW(tinycoro::GetAll(scheduler, std::move(tasks)));
+    EXPECT_NO_THROW(tinycoro::AllOf(scheduler, std::move(tasks)));
 }
 
 TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_paramMulti_destructorClose)
@@ -1303,7 +1303,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_paramMulti_destructorC
     }
     tasks.push_back(producer());
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     EXPECT_EQ(allValues.size(), count);
 }
@@ -1348,7 +1348,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_param_autoEvent)
         channel.Close();
     };
 
-    tinycoro::GetAll(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer(), consumer());
+    tinycoro::AllOf(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer(), consumer());
 
     EXPECT_EQ(allValues.size(), count);
 }
@@ -1386,7 +1386,7 @@ TEST_P(BufferedChannelTest, BufferedChannelTest_PushClose)
         }
     }
 
-    tinycoro::GetAll(scheduler, consumer());
+    tinycoro::AllOf(scheduler, consumer());
 }
 
 TEST(BufferedChannelTest, BufferedChannelTest_PushCloseMulti)
@@ -1418,7 +1418,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_PushCloseMulti)
         EXPECT_THROW(channel.Push(33u), tinycoro::BufferedChannelException);
     };
 
-    tinycoro::GetAll(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer());
 
     EXPECT_EQ(allValues.size(), 4);
 
@@ -1694,7 +1694,7 @@ TEST_P(BufferedChannelTest, BufferedChannelTest_PushClose_multi)
     }
     tasks.push_back(producer());
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     EXPECT_EQ(lastValue, count - 1);
     EXPECT_EQ(allValues.size(), count);
@@ -1755,7 +1755,7 @@ TEST_P(BufferedChannelTest, BufferedChannelTest_PushCloseWait_multi)
     }
     tasks.push_back(producer());
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     EXPECT_EQ(lastValue, count - 1);
     EXPECT_EQ(allValues.size(), count);
@@ -1801,7 +1801,7 @@ TEST_P(BufferedChannelTest, BufferedChannelTest_WaitPush_singleThread_minQueueSi
         channel.Close();
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 
     EXPECT_EQ(currentValue, count);
     EXPECT_EQ(allValues.size(), count);
@@ -1844,7 +1844,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_pushWait_fixedQueueSiz
         EXPECT_EQ(tinycoro::EChannelOpStatus::LAST, co_await channel.PushAndCloseWait(count - 1));
     };
 
-    tinycoro::GetAll(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer(), consumer());
+    tinycoro::AllOf(scheduler, consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), producer(), consumer());
 
     EXPECT_EQ(allValues.size(), count);
 }
@@ -1879,7 +1879,7 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_pushWait_close_fixedQu
     }
     tasks.push_back(producer());
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_tryPush)
@@ -1919,5 +1919,5 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_tryPush)
         co_return;
     };
 
-    tinycoro::GetAll(scheduler, producer(), consumer());
+    tinycoro::AllOf(scheduler, producer(), consumer());
 }

--- a/test/src/Example_tests.cpp
+++ b/test/src/Example_tests.cpp
@@ -260,7 +260,7 @@ TEST_F(ExampleTest, Example_multiTaskDifferentValues)
 
     auto task3 = []() -> tinycoro::Task<S> { co_return 43; };
 
-    auto results = tinycoro::GetAll(scheduler, task1(), task2(), task3());
+    auto results = tinycoro::AllOf(scheduler, task1(), task2(), task3());
 
     auto voidType = std::get<0>(results);
 
@@ -389,7 +389,7 @@ TEST_F(ExampleTest, Example_asyncCallbackAwaiter_exception)
         co_return 42;
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
     EXPECT_EQ(val, 42);
 }
 
@@ -408,7 +408,7 @@ TEST_F(ExampleTest, Example_asyncCallbackAwaiter_void_exception)
             cb), std::runtime_error);
     };
 
-    EXPECT_NO_THROW(tinycoro::GetAll(scheduler, task()));
+    EXPECT_NO_THROW(tinycoro::AllOf(scheduler, task()));
 }
 
 TEST_F(ExampleTest, Example_asyncCallbackAwaiter_CStyle)
@@ -462,7 +462,7 @@ TEST_F(ExampleTest, Example_asyncCallbackAwaiter_CStyle_exception)
         co_return userData;
     };
 
-    auto val = tinycoro::GetAll(scheduler, task());
+    auto val = tinycoro::AllOf(scheduler, task());
     EXPECT_EQ(val, 21);
 }
 
@@ -506,7 +506,7 @@ TEST_F(ExampleTest, Example_asyncCallbackAwaiter_CStyleVoid_exception)
         co_await task2();
     };
 
-    EXPECT_NO_THROW(tinycoro::GetAll(scheduler, task1()));
+    EXPECT_NO_THROW(tinycoro::AllOf(scheduler, task1()));
 }
 
 TEST_F(ExampleTest, Example_asyncCallbackAwaiterWithReturnValue)
@@ -589,7 +589,7 @@ TEST_F(ExampleTest, Example_AnyOfVoid)
     };
 
     std::stop_source source;
-    EXPECT_NO_THROW(tinycoro::AnyOfWithStopSource(scheduler, source, task1(1s), task1(2s), task1(3s)));
+    EXPECT_NO_THROW(tinycoro::AnyOf(scheduler, source, task1(1s), task1(2s), task1(3s)));
 }
 
 TEST_F(ExampleTest, Example_AnyOf)
@@ -663,7 +663,7 @@ TEST_F(ExampleTest, Example_AnyOfDynamicVoid)
     tasks.push_back(task1(20ms));
     tasks.push_back(task1(30ms));
 
-    EXPECT_NO_THROW(tinycoro::AnyOfWithStopSource(scheduler, source, std::move(tasks)));
+    EXPECT_NO_THROW(tinycoro::AnyOf(scheduler, source, std::move(tasks)));
 }
 
 TEST_F(ExampleTest, Example_AnyOfVoidException)
@@ -743,7 +743,7 @@ TEST_F(ExampleTest, ExampleSyncAwait)
         auto task3 = []() -> tinycoro::Task<std::string> { co_return "123"; };
 
         // waiting to finish all other tasks. (non blocking)
-        auto tupleResult = co_await tinycoro::SyncAwait(scheduler, task1(), task2(), task3());
+        auto tupleResult = co_await tinycoro::AllOfAwait(scheduler, task1(), task2(), task3());
 
         // tuple accumulate
         co_return std::apply(
@@ -770,7 +770,7 @@ TEST_F(ExampleTest, ExampleSyncAwaitException)
         auto task3 = []() -> tinycoro::Task<std::string> { co_return "123"; };
 
         // waiting to finish all other tasks. (non blocking)
-        auto tupleResult = co_await tinycoro::SyncAwait(scheduler, task1(), task2(), task3());
+        auto tupleResult = co_await tinycoro::AllOfAwait(scheduler, task1(), task2(), task3());
 
         // tuple accumulate
         co_return std::apply(
@@ -806,7 +806,7 @@ TEST_F(ExampleTest, ExampleAnyOfCoAwait)
 
         auto stopSource = co_await tinycoro::this_coro::stop_source();
 
-        auto [t1, t2, t3] = co_await tinycoro::AnyOfStopSourceAwait(scheduler, stopSource, task1(100ms), task1(2s), task1(3s));
+        auto [t1, t2, t3] = co_await tinycoro::AnyOfAwait(scheduler, stopSource, task1(100ms), task1(2s), task1(3s));
 
         EXPECT_TRUE(*t1 > 0);
         EXPECT_FALSE(t2.has_value());
@@ -815,5 +815,5 @@ TEST_F(ExampleTest, ExampleAnyOfCoAwait)
         EXPECT_TRUE(std::chrono::system_clock::now() - now < 500ms);
     };
 
-    EXPECT_NO_THROW(tinycoro::GetAll(scheduler, anyOfCoAwaitTest(scheduler)));
+    EXPECT_NO_THROW(tinycoro::AllOf(scheduler, anyOfCoAwaitTest(scheduler)));
 }

--- a/test/src/Example_tests.cpp
+++ b/test/src/Example_tests.cpp
@@ -735,7 +735,7 @@ TEST_F(ExampleTest, ExampleOwnAwaiter)
     EXPECT_EQ(*val, 42);
 }
 
-TEST_F(ExampleTest, ExampleSyncAwait)
+TEST_F(ExampleTest, ExampleAllOfAwait)
 {
     auto syncAwait = [](auto& scheduler) -> tinycoro::Task<std::string> {
         auto task1 = []() -> tinycoro::Task<std::string> { co_return "123"; };
@@ -759,7 +759,7 @@ TEST_F(ExampleTest, ExampleSyncAwait)
     EXPECT_EQ(std::string{"123123123"}, future.get().value());
 }
 
-TEST_F(ExampleTest, ExampleSyncAwaitException)
+TEST_F(ExampleTest, ExampleAllOfAwaitException)
 {
     auto syncAwait = [](auto& scheduler) -> tinycoro::Task<std::string> {
         auto task1 = []() -> tinycoro::Task<std::string> {

--- a/test/src/InlineTask_test.cpp
+++ b/test/src/InlineTask_test.cpp
@@ -18,7 +18,7 @@ TEST(InlineTaskTest, InlineTaskTest)
         EXPECT_EQ(val, 42);
     };
 
-    tinycoro::GetAll(scheduler, task());
+    tinycoro::AllOf(scheduler, task());
 }
 
 TEST(InlineTaskTest, InlineTaskTest_run_inline)
@@ -30,7 +30,7 @@ TEST(InlineTaskTest, InlineTaskTest_run_inline)
         co_return val += 1;
     };
 
-    auto val = tinycoro::RunInline(inlineTask1());
+    auto val = tinycoro::AllOfInline(inlineTask1());
 
     EXPECT_EQ(val, 42);
 }
@@ -58,7 +58,7 @@ TEST(InlineTaskTest, InlineTaskTest_nested_resume)
         co_return val;
     };
 
-    auto val = tinycoro::RunInline(task3(0));
+    auto val = tinycoro::AllOfInline(task3(0));
 
     EXPECT_EQ(val, 3);
 }

--- a/test/src/IntrusivePtr_test.cpp
+++ b/test/src/IntrusivePtr_test.cpp
@@ -258,5 +258,5 @@ TEST(IntrusivePtrTest, IntrusivePtrTest_async)
         // all refs are released...
     };
 
-    tinycoro::GetAll(scheduler, task(), task2(), task2(), task2(), task2());
+    tinycoro::AllOf(scheduler, task(), task2(), task2(), task2(), task2());
 }

--- a/test/src/Latch_test.cpp
+++ b/test/src/Latch_test.cpp
@@ -185,7 +185,7 @@ TEST_P(LatchTest, LatchFunctionalTest_ArriveAndWait)
         tasks.emplace_back(task());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
     EXPECT_EQ(count, latchCount);
 }
 
@@ -251,7 +251,7 @@ TEST_P(LatchTest, LatchFunctionalTest_Wait)
         tasks.emplace_back(countDown());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
     EXPECT_EQ(count, latchCount);
 }
 
@@ -290,7 +290,7 @@ TEST_P(LatchTest, LatchFunctionalTest_coawait)
         tasks.emplace_back(countDown());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
     EXPECT_EQ(count, latchCount_1);
     EXPECT_EQ(count, latchCount_2);
 }

--- a/test/src/ManualEvent_test.cpp
+++ b/test/src/ManualEvent_test.cpp
@@ -167,7 +167,7 @@ TEST_P(ManualEventTest, ManualEventFunctionalTest)
     }
     tasks.push_back(trigger());
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     EXPECT_EQ(globalCount, count);
 }
@@ -196,7 +196,7 @@ TEST_P(ManualEventTest, ManualEventFunctionalTest_preSet)
     // preset the event
     event.Set();
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     EXPECT_EQ(globalCount, count);
 }

--- a/test/src/Mutex_test.cpp
+++ b/test/src/Mutex_test.cpp
@@ -63,7 +63,7 @@ TEST_P(MutexTest, MutexFunctionalTest_1)
         tasks.push_back(task());
     }
 
-    auto results = tinycoro::GetAll(scheduler, std::move(tasks));
+    auto results = tinycoro::AllOf(scheduler, std::move(tasks));
 
     // check for unique values
     std::set<size_t> set;
@@ -101,7 +101,7 @@ TEST_P(MutexStressTest, MutexFunctionalStressTest_1)
     };
 
     // starting 8 async tasks at the same time
-    tinycoro::GetAll(scheduler, task(), task(), task(), task(), task(), task(), task(), task());
+    tinycoro::AllOf(scheduler, task(), task(), task(), task(), task(), task(), task(), task());
 
     EXPECT_EQ(count, size * 8);
 }

--- a/test/src/Semaphore_test.cpp
+++ b/test/src/Semaphore_test.cpp
@@ -190,7 +190,7 @@ TEST_F(SemapthoreFunctionalTest, SemapthoreFunctionalTest_exampleTest)
         co_return ++count;
     };
 
-    auto [c1, c2, c3] = tinycoro::GetAll(scheduler, task(), task(), task());
+    auto [c1, c2, c3] = tinycoro::AllOf(scheduler, task(), task(), task());
 
     EXPECT_TRUE(c1 != c2 && c2 != c3 && c3 != c1);
     EXPECT_EQ(count, 3);
@@ -215,7 +215,7 @@ TEST_P(SemapthoreFunctionalTest, SemapthoreFunctionalTest_counter)
         tasks.emplace_back(task());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
     EXPECT_EQ(count, param);
 }
 
@@ -244,7 +244,7 @@ TEST_P(SemapthoreFunctionalTest, SemapthoreFunctionalTest_counter_double)
         tasks.emplace_back(task());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
     EXPECT_EQ(count, param * 2);
 }
 
@@ -280,7 +280,7 @@ TEST_P(SemapthoreFunctionalTest, SemapthoreFunctionalTest_counter_max)
         tasks.emplace_back(task());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
     EXPECT_TRUE(max <= 4);
 }
 
@@ -309,7 +309,7 @@ TEST_P(SemaphoreStressTest, SemaphoreStressTest_1)
     };
 
     // starting 8 async tasks at the same time
-    tinycoro::GetAll(scheduler, task(), task(), task(), task(), task(), task(), task(), task());
+    tinycoro::AllOf(scheduler, task(), task(), task(), task(), task(), task(), task(), task());
 
     EXPECT_EQ(count, size * 8);
 }

--- a/test/src/SingleEvent_test.cpp
+++ b/test/src/SingleEvent_test.cpp
@@ -147,7 +147,7 @@ TEST(SingleEventTest, SingleEventFunctionalTest_1)
         EXPECT_EQ(val, 42);
     };
 
-    tinycoro::GetAll(scheduler, producer(), consumer());
+    tinycoro::AllOf(scheduler, producer(), consumer());
 }
 
 TEST(SingleEventTest, SingleEventFunctionalTest_2)
@@ -183,7 +183,7 @@ TEST(SingleEventTest, SingleEventFunctionalTest_2)
         }
     };
 
-    tinycoro::GetAll(scheduler, producer(), consumer());
+    tinycoro::AllOf(scheduler, producer(), consumer());
 }
 
 TEST(SingleEventTest, SingleEventTest_cancel)

--- a/test/src/SleepAwaiter_test.cpp
+++ b/test/src/SleepAwaiter_test.cpp
@@ -127,7 +127,7 @@ TEST_F(SleepAwaiterTest, SimpleSleepAwaiterTest_interrupt_sleep)
 
     auto start  = std::chrono::system_clock::now();
 
-    tinycoro::GetAll(scheduler, stopRequester(), sleepInterruptTask(timeout1), sleepInterruptTask(timeout2));
+    tinycoro::AllOf(scheduler, stopRequester(), sleepInterruptTask(timeout1), sleepInterruptTask(timeout2));
 
     auto end = std::chrono::system_clock::now();
 
@@ -170,7 +170,7 @@ TEST_F(SleepAwaiterTest, SimpleSleepAwaiterTest_interrupt_sleep_cancellable)
 
     auto start = std::chrono::system_clock::now();
 
-    tinycoro::GetAll(scheduler, stopRequester(), sleepInterruptTask(timeout1));
+    tinycoro::AllOf(scheduler, stopRequester(), sleepInterruptTask(timeout1));
 
     auto end = std::chrono::system_clock::now();
 
@@ -233,6 +233,6 @@ TEST_P(SleepAwaiterStressTest, SleepAwaiterStressTest_sleepFor)
             co_await tinycoro::SleepFor<SleepAwaiterStressTest::Allocator>(clock, duration);
         };
 
-        EXPECT_NO_THROW(tinycoro::AnyOfWithStopSource(scheduler, source, task(1ms), task(2s), task(3s)));
+        EXPECT_NO_THROW(tinycoro::AnyOf(scheduler, source, task(1ms), task(2s), task(3s)));
     }
 }

--- a/test/src/SoftClock_test.cpp
+++ b/test/src/SoftClock_test.cpp
@@ -316,7 +316,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_wait_complition_token)
     auto waiter = [&latch]() -> tinycoro::Task<void> { co_await latch; };
 
     // waits for all the events
-    tinycoro::RunInline(waiter());
+    tinycoro::AllOfInline(waiter());
 }
 
 TEST_P(SoftClockTest, SoftClockFunctionalTest_requestStop_test)
@@ -369,7 +369,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_wait_complition)
     auto waiter = [&latch]() -> tinycoro::Task<void> { co_await latch; };
 
     // waits for all the events
-    tinycoro::RunInline(waiter());
+    tinycoro::AllOfInline(waiter());
 }
 
 TEST_P(SoftClockTest, SoftClockFunctionalTest_wait_complition_token_cancel)
@@ -398,7 +398,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_wait_complition_token_cancel)
     auto waiter = [&latch]() -> tinycoro::Task<void> { co_await latch; };
 
     // waits for all the events
-    tinycoro::RunInline(waiter());
+    tinycoro::AllOfInline(waiter());
 }
 
 TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded)
@@ -429,7 +429,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded)
         tasks.push_back(setTimer());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     EXPECT_EQ(count, c);
 }
@@ -457,7 +457,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_measure_1)
         tasks.push_back(measure());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_measure_timedOut)
@@ -492,7 +492,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_measure_timedOut)
         
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_measure_1_random)
@@ -522,7 +522,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_measure_1_random)
         tasks.push_back(measure());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_measure_2)
@@ -548,7 +548,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_measure_2)
         tasks.push_back(measure());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_measure_2_random)
@@ -578,7 +578,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_measure_2_random)
         tasks.push_back(measure());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 }
 
 TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_with_token)
@@ -609,7 +609,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_with_token)
         tasks.push_back(setTimer());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     EXPECT_EQ(count, c);
 }
@@ -638,7 +638,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_with_token_cancel)
         tasks.push_back(setTimer());
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     // should be 0
     EXPECT_EQ(0, c);
@@ -679,7 +679,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_with_token_cancel_st
 
     tasks.push_back(canceller());
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     // should be 0
     EXPECT_EQ(0, c);
@@ -720,7 +720,7 @@ TEST_P(SoftClockTest, SoftClockFunctionalTest_multiThreaded_close)
         }
     }
 
-    tinycoro::GetAll(scheduler, std::move(tasks));
+    tinycoro::AllOf(scheduler, std::move(tasks));
 
     // should be 0
     EXPECT_EQ(0, c);

--- a/test/src/SyncAwaiter_test.cpp
+++ b/test/src/SyncAwaiter_test.cpp
@@ -90,7 +90,7 @@ struct SchedulerMock
     }
 };
 
-struct SyncAwaiterTest : testing::Test
+struct AllOfAwaiterTest : testing::Test
 {
     void SetUp() override
     {
@@ -104,7 +104,7 @@ protected:
     SchedulerMock schedulerMock;
 };
 
-TEST_F(SyncAwaiterTest, SyncAwaiterTest_voidTask)
+TEST_F(AllOfAwaiterTest, AllOfAwaiterTest_voidTask)
 {
     auto task    = []() -> tinycoro::Task<void> { co_return; };
     auto awaiter = tinycoro::AllOfAwait(schedulerMock, task(), task());
@@ -116,7 +116,7 @@ TEST_F(SyncAwaiterTest, SyncAwaiterTest_voidTask)
     EXPECT_NO_THROW(awaiter.await_resume());
 }
 
-TEST_F(SyncAwaiterTest, SyncAwaiterTest_vector_voidTask)
+TEST_F(AllOfAwaiterTest, AllOfAwaiterTest_vector_voidTask)
 {
     auto task = []() -> tinycoro::Task<void> { co_return; };
 
@@ -133,7 +133,7 @@ TEST_F(SyncAwaiterTest, SyncAwaiterTest_vector_voidTask)
     EXPECT_NO_THROW(awaiter.await_resume());
 }
 
-TEST_F(SyncAwaiterTest, SyncAwaiterTest_intTask)
+TEST_F(AllOfAwaiterTest, AllOfAwaiterTest_intTask)
 {
     auto task    = []() -> tinycoro::Task<int32_t> { co_return 0; };
     auto awaiter = tinycoro::AllOfAwait(schedulerMock, task(), task(), task());
@@ -150,7 +150,7 @@ TEST_F(SyncAwaiterTest, SyncAwaiterTest_intTask)
     EXPECT_EQ(r3, 0);
 }
 
-TEST_F(SyncAwaiterTest, SyncAwaiterTest_array_intTask)
+TEST_F(AllOfAwaiterTest, AllOfAwaiterTest_array_intTask)
 {
     auto task = []() -> tinycoro::Task<int32_t> { co_return 0; };
 
@@ -173,7 +173,7 @@ TEST_F(SyncAwaiterTest, SyncAwaiterTest_array_intTask)
     EXPECT_EQ(results[2], 0);
 }
 
-TEST_F(SyncAwaiterTest, AnyOfAwait_intTask)
+TEST_F(AllOfAwaiterTest, AnyOfAwait_intTask)
 {
     auto task    = []() -> tinycoro::Task<int32_t> { co_return 0; };
     auto awaiter = tinycoro::AnyOfAwait(schedulerMock, task(), task(), task());
@@ -190,7 +190,7 @@ TEST_F(SyncAwaiterTest, AnyOfAwait_intTask)
     EXPECT_EQ(std::get<2>(results), 0);
 }
 
-TEST_F(SyncAwaiterTest, AnyOfAwaitStopSource_intTask)
+TEST_F(AllOfAwaiterTest, AnyOfAwaitStopSource_intTask)
 {
     std::stop_source ss;
 
@@ -320,7 +320,7 @@ TEST(AnyOfCoAwaitTest2, AnyOfCoAwaitTest2)
     EXPECT_NO_THROW(tinycoro::GetAll(future));
 }
 
-TEST_F(SyncAwaiterTest, SyncAwaiterTest_callOrder)
+TEST_F(AllOfAwaiterTest, AllOfAwaiterTest_callOrder)
 {
     tinycoro::Scheduler scheduler{1};
 
@@ -352,13 +352,13 @@ TEST_F(SyncAwaiterTest, SyncAwaiterTest_callOrder)
     EXPECT_TRUE(breakfast == "toast + coffee + tee");
 }
 
-struct SyncAwaiterDynamicTest : testing::TestWithParam<size_t>
+struct AllOfAwaiterDynamicTest : testing::TestWithParam<size_t>
 {
 };
 
-INSTANTIATE_TEST_SUITE_P(SyncAwaiterDynamicTest, SyncAwaiterDynamicTest, testing::Values(1, 10, 100, 1000, 10000));
+INSTANTIATE_TEST_SUITE_P(AllOfAwaiterDynamicTest, AllOfAwaiterDynamicTest, testing::Values(1, 10, 100, 1000, 10000));
 
-TEST_P(SyncAwaiterDynamicTest, SyncAwaiterDynamicFuntionalTest_1)
+TEST_P(AllOfAwaiterDynamicTest, AllOfAwaiterDynamicFuntionalTest_1)
 {
     tinycoro::Scheduler scheduler{16};
 
@@ -393,7 +393,7 @@ TEST_P(SyncAwaiterDynamicTest, SyncAwaiterDynamicFuntionalTest_1)
     tinycoro::AllOfInline(coro());
 }
 
-TEST_P(SyncAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_1)
+TEST_P(AllOfAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_1)
 {
     tinycoro::Scheduler scheduler{16};
 
@@ -430,7 +430,7 @@ TEST_P(SyncAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_1)
     tinycoro::AllOfInline(coro());
 }
 
-TEST_P(SyncAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_2)
+TEST_P(AllOfAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_2)
 {
     // only 1 thread
     tinycoro::Scheduler scheduler{1};
@@ -467,7 +467,7 @@ TEST_P(SyncAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_2)
     tinycoro::AllOfInline(coro());
 }
 
-TEST(SyncAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_3)
+TEST(AllOfAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_3)
 {
     tinycoro::SoftClock clock;
     // scheduler with only 1 thread
@@ -503,7 +503,7 @@ TEST(SyncAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_3)
     tinycoro::AllOfInline(coro());
 }
 
-TEST(SyncAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_exception)
+TEST(AllOfAwaiterDynamicTest, AnyOfAwaitDynamicFuntionalTest_exception)
 {
     tinycoro::SoftClock clock;
     // scheduler with only 1 thread

--- a/test/src/UnbufferedChannel_test.cpp
+++ b/test/src/UnbufferedChannel_test.cpp
@@ -264,7 +264,7 @@ TEST(UnbufferedChannelTest, UnbufferedChannelFunctionalTest_simple)
         EXPECT_EQ(status, tinycoro::EChannelOpStatus::SUCCESS);
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 }
 
 TEST(UnbufferedChannelTest, UnbufferedChannelFunctionalTest_simple_push)
@@ -312,7 +312,7 @@ TEST(UnbufferedChannelTest, UnbufferedChannelFunctionalTest_simple_pop_before_pu
         EXPECT_EQ(result, tinycoro::EChannelOpStatus::SUCCESS);
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 }
 
 TEST(UnbufferedChannelTest, UnbufferedChannelFunctionalTest_simple_push_and_close)
@@ -356,7 +356,7 @@ TEST(UnbufferedChannelTest, UnbufferedChannelFunctionalTest_lastElement)
         EXPECT_EQ(status, tinycoro::EChannelOpStatus::LAST);
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 }
 
 TEST(UnbufferedChannelTest, UnbufferedChannelFunctionalTest_close)
@@ -385,7 +385,7 @@ TEST(UnbufferedChannelTest, UnbufferedChannelFunctionalTest_close)
         EXPECT_EQ(status, tinycoro::EChannelOpStatus::CLOSED);
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 }
 
 TEST(UnbufferedChannelTest, UnbufferedChannelTest_cleanup_callback_pushWait)
@@ -411,7 +411,7 @@ TEST(UnbufferedChannelTest, UnbufferedChannelTest_cleanup_callback_pushWait)
         channel.Close();
     };
 
-    tinycoro::RunInline(producer(40), producer(41), producer(42), producer(43), producer(44), consumer(40), consumer(41), closer());
+    tinycoro::AllOfInline(producer(40), producer(41), producer(42), producer(43), producer(44), consumer(40), consumer(41), closer());
 
     EXPECT_EQ(coll.size(), 3);
 
@@ -436,7 +436,7 @@ TEST(UnbufferedChannelTest, UnbufferedChannelTest_pop_awaiter_listener)
         EXPECT_EQ(val, expected);
     };
 
-    tinycoro::RunInline(waitForListeners(), consumer(40), consumer(41), consumer(42), producer(40), producer(41), producer(42));
+    tinycoro::AllOfInline(waitForListeners(), consumer(40), consumer(41), consumer(42), producer(40), producer(41), producer(42));
 }
 
 TEST(UnbufferedChannelTest, UnbufferedChannelTest_cancel)
@@ -546,7 +546,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_param)
         channel.Close();
     };
 
-    tinycoro::GetAll(scheduler, producer(), consumer());
+    tinycoro::AllOf(scheduler, producer(), consumer());
     EXPECT_EQ(allValues.size(), count);
 }
 
@@ -582,7 +582,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_paramMulti)
         channel.Close();
     };
 
-    tinycoro::GetAll(scheduler, producer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer());
+    tinycoro::AllOf(scheduler, producer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer());
     EXPECT_EQ(allValues.size(), count);
 }
 
@@ -623,7 +623,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_PushAndClose)
         }
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 }
 
 TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_PushAndClose_multi)
@@ -664,7 +664,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_PushAndClose_multi)
         }
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer());
+    tinycoro::AllOf(scheduler, consumer(), producer(), consumer(), consumer(), consumer(), consumer(), consumer(), consumer());
     EXPECT_EQ(allValues.size(), count);
 }
 
@@ -704,7 +704,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_push_pop_close)
         channel.Close();
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer(), consumer(), consumer(), consumer(), consumer(), closer());
+    tinycoro::AllOf(scheduler, consumer(), producer(), consumer(), consumer(), consumer(), consumer(), closer());
 
     // check for values
     bool found{true};
@@ -749,7 +749,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_simple_push)
         co_return;
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 }
 
 TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_simple_pushAndClose)
@@ -782,7 +782,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_simple_pushAndClose)
         co_return;
     };
 
-    tinycoro::GetAll(scheduler, consumer(), producer());
+    tinycoro::AllOf(scheduler, consumer(), producer());
 }
 
 TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_waitForListeners)
@@ -810,7 +810,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_waitForListeners)
         tasks.push_back(listeners());
     }
 
-    EXPECT_NO_THROW(tinycoro::GetAll(scheduler, std::move(tasks)));
+    EXPECT_NO_THROW(tinycoro::AllOf(scheduler, std::move(tasks)));
 }
 
 TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_waitForListeners_multi_waiters)
@@ -838,7 +838,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_waitForListeners_multi_waite
         tasks.push_back(producer());
     }
 
-    EXPECT_NO_THROW(tinycoro::GetAll(scheduler, std::move(tasks)));
+    EXPECT_NO_THROW(tinycoro::AllOf(scheduler, std::move(tasks)));
 }
 
 TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_waitForListenersClose)
@@ -863,7 +863,7 @@ TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_waitForListenersClose)
     }
     tasks.push_back(producer());
 
-    EXPECT_NO_THROW(tinycoro::GetAll(scheduler, std::move(tasks)));
+    EXPECT_NO_THROW(tinycoro::AllOf(scheduler, std::move(tasks)));
 }
 
 TEST_P(UnbufferedChannelTest, UnbufferedChannelTest_PushWait_cancel)

--- a/test/src/WaitInline_test.cpp
+++ b/test/src/WaitInline_test.cpp
@@ -5,10 +5,10 @@
 
 #include <tinycoro/tinycoro_all.h>
 
-struct RunInline_PauseHandlerMock
+struct WaitInline_PauseHandlerMock
 {
-    RunInline_PauseHandlerMock() = default;
-    RunInline_PauseHandlerMock(tinycoro::PauseHandlerCallbackT c)
+    WaitInline_PauseHandlerMock() = default;
+    WaitInline_PauseHandlerMock(tinycoro::PauseHandlerCallbackT c)
     : cb{c}
     {
     }
@@ -26,7 +26,7 @@ struct PromiseMock
 };
 
 template<typename ReturnT, typename PauseHandlerT>
-struct RunInline_TaskMock
+struct WaitInline_TaskMock
 {
     using value_type = ReturnT;
 
@@ -44,13 +44,13 @@ struct RunInline_TaskMock
 };
 
 template<typename ReturnT, typename PauseHandlerT>
-struct RunInline_TaskMockWrapper
+struct WaitInline_TaskMockWrapper
 {
     using value_type = ReturnT;
     using promise_type = PromiseMock<ReturnT>;
 
-    RunInline_TaskMockWrapper()
-    : mock{std::make_shared<RunInline_TaskMock<ReturnT, PauseHandlerT>>()}
+    WaitInline_TaskMockWrapper()
+    : mock{std::make_shared<WaitInline_TaskMock<ReturnT, PauseHandlerT>>()}
     {
         ON_CALL(*mock, IsDone).WillByDefault(::testing::Return(true));
     }
@@ -101,17 +101,17 @@ struct RunInline_TaskMockWrapper
         return mock->IsDone();
     }
 
-    std::shared_ptr<RunInline_TaskMock<ReturnT, PauseHandlerT>> mock;
+    std::shared_ptr<WaitInline_TaskMock<ReturnT, PauseHandlerT>> mock;
 };
 
 
-TEST(RunInlineTest, RunInlineTest_void)
+TEST(WaitInlineTest, WaitInlineTest_void)
 {
-    RunInline_TaskMockWrapper<void, RunInline_PauseHandlerMock> mock;
+    WaitInline_TaskMockWrapper<void, WaitInline_PauseHandlerMock> mock;
 
     EXPECT_CALL(*mock.mock, SetPauseHandler(testing::_)).WillOnce(testing::Invoke(
         [&mock] (auto callback) {
-            mock.mock->pauseHandlerMock = std::make_shared<RunInline_PauseHandlerMock>(callback);
+            mock.mock->pauseHandlerMock = std::make_shared<WaitInline_PauseHandlerMock>(callback);
             return mock.mock->pauseHandlerMock;
         }
     ));
@@ -125,13 +125,13 @@ TEST(RunInlineTest, RunInlineTest_void)
     tinycoro::AllOfInline(mock);
 }
 
-TEST(RunInlineTest, RunInlineTest_int32)
+TEST(WaitInlineTest, WaitInlineTest_int32)
 {
-    RunInline_TaskMockWrapper<int32_t, RunInline_PauseHandlerMock> mock;
+    WaitInline_TaskMockWrapper<int32_t, WaitInline_PauseHandlerMock> mock;
 
     EXPECT_CALL(*mock.mock, SetPauseHandler(testing::_)).WillOnce(testing::Invoke(
         [&mock] (auto callback) {
-            mock.mock->pauseHandlerMock = std::make_shared<RunInline_PauseHandlerMock>(callback);
+            mock.mock->pauseHandlerMock = std::make_shared<WaitInline_PauseHandlerMock>(callback);
             return mock.mock->pauseHandlerMock;
         }
     ));
@@ -154,13 +154,13 @@ TEST(RunInlineTest, RunInlineTest_int32)
     EXPECT_EQ(42, val);
 }
 
-TEST(RunInlineTest, RunInlineTest_pause)
+TEST(WaitInlineTest, WaitInlineTest_pause)
 {
-    RunInline_TaskMock<int32_t, RunInline_PauseHandlerMock> mock;
+    WaitInline_TaskMock<int32_t, WaitInline_PauseHandlerMock> mock;
 
     EXPECT_CALL(mock, SetPauseHandler(testing::_)).WillOnce(testing::Invoke(
         [&mock] (auto callback) {
-            mock.pauseHandlerMock = std::make_shared<RunInline_PauseHandlerMock>(callback);
+            mock.pauseHandlerMock = std::make_shared<WaitInline_PauseHandlerMock>(callback);
 
             EXPECT_CALL(*mock.pauseHandlerMock, Resume()).Times(1);
 
@@ -197,13 +197,13 @@ TEST(RunInlineTest, RunInlineTest_pause)
     EXPECT_EQ(42, val);
 }
 
-TEST(RunInlineTest, RunInlineTest_cancelled)
+TEST(WaitInlineTest, WaitInlineTest_cancelled)
 {
-    RunInline_TaskMockWrapper<int32_t, RunInline_PauseHandlerMock> mock;
+    WaitInline_TaskMockWrapper<int32_t, WaitInline_PauseHandlerMock> mock;
 
     EXPECT_CALL(*mock.mock, SetPauseHandler(testing::_)).WillOnce(testing::Invoke(
         [&mock] (auto callback) {
-            mock.mock->pauseHandlerMock = std::make_shared<RunInline_PauseHandlerMock>(callback);
+            mock.mock->pauseHandlerMock = std::make_shared<WaitInline_PauseHandlerMock>(callback);
             return mock.mock->pauseHandlerMock;
         }
     ));
@@ -225,11 +225,11 @@ TEST(RunInlineTest, RunInlineTest_cancelled)
     EXPECT_FALSE(val.has_value());
 }
 
-TEST(RunInlineTest, RunInlineTest_multiTasks)
+TEST(WaitInlineTest, WaitInlineTest_multiTasks)
 {
-    RunInline_TaskMock<int32_t, RunInline_PauseHandlerMock> mock1;
+    WaitInline_TaskMock<int32_t, WaitInline_PauseHandlerMock> mock1;
 
-    mock1.pauseHandlerMock = std::make_shared<RunInline_PauseHandlerMock>();
+    mock1.pauseHandlerMock = std::make_shared<WaitInline_PauseHandlerMock>();
 
     EXPECT_CALL(mock1, IsDone)
         .WillOnce(testing::Return(false))
@@ -251,9 +251,9 @@ TEST(RunInlineTest, RunInlineTest_multiTasks)
 
     EXPECT_CALL(mock1, await_resume()).Times(1).WillOnce(testing::Return(42));
 
-    RunInline_TaskMock<int32_t, RunInline_PauseHandlerMock> mock2;
+    WaitInline_TaskMock<int32_t, WaitInline_PauseHandlerMock> mock2;
 
-    mock2.pauseHandlerMock = std::make_shared<RunInline_PauseHandlerMock>();
+    mock2.pauseHandlerMock = std::make_shared<WaitInline_PauseHandlerMock>();
 
     EXPECT_CALL(mock2, IsDone)
         .WillOnce(testing::Return(false))
@@ -281,15 +281,15 @@ TEST(RunInlineTest, RunInlineTest_multiTasks)
     EXPECT_EQ(43, result2);
 }
 
-TEST(RunInlineTest, RunInlineTest_dynamicTasks)
+TEST(WaitInlineTest, WaitInlineTest_dynamicTasks)
 {
-    std::vector<RunInline_TaskMockWrapper<int32_t, RunInline_PauseHandlerMock>> tasks;
+    std::vector<WaitInline_TaskMockWrapper<int32_t, WaitInline_PauseHandlerMock>> tasks;
 
     for(size_t i=0; i < 10; ++i)
     {
         tasks.emplace_back();
 
-        tasks[i].mock->pauseHandlerMock = std::make_shared<RunInline_PauseHandlerMock>();
+        tasks[i].mock->pauseHandlerMock = std::make_shared<WaitInline_PauseHandlerMock>();
 
         EXPECT_CALL(*tasks[i].mock, SetPauseHandler(testing::_)).WillOnce(testing::Invoke(
         [&tasks, index = i] (auto) {
@@ -316,15 +316,15 @@ TEST(RunInlineTest, RunInlineTest_dynamicTasks)
     });
 }
 
-TEST(RunInlineTest, RunInlineTest_dynamicTasks_cancelled)
+TEST(WaitInlineTest, WaitInlineTest_dynamicTasks_cancelled)
 {
-    std::vector<RunInline_TaskMockWrapper<int32_t, RunInline_PauseHandlerMock>> tasks;
+    std::vector<WaitInline_TaskMockWrapper<int32_t, WaitInline_PauseHandlerMock>> tasks;
 
     for(size_t i=0; i < 10; ++i)
     {
         tasks.emplace_back();
 
-        tasks[i].mock->pauseHandlerMock = std::make_shared<RunInline_PauseHandlerMock>();
+        tasks[i].mock->pauseHandlerMock = std::make_shared<WaitInline_PauseHandlerMock>();
 
         EXPECT_CALL(*tasks[i].mock, SetPauseHandler(testing::_)).WillOnce(testing::Invoke(
         [&tasks, index = i] (auto) {
@@ -352,7 +352,7 @@ TEST(RunInlineTest, RunInlineTest_dynamicTasks_cancelled)
     });
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_voidTasks)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_voidTasks)
 {
     size_t i = 0;
 
@@ -378,7 +378,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_voidTasks)
     EXPECT_EQ(i, 3);
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_1)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_1)
 {
     tinycoro::SingleEvent<int32_t> event;
 
@@ -394,7 +394,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_1)
     EXPECT_EQ(value, 42);
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_2)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_2)
 {
     tinycoro::SoftClock clock;
     tinycoro::SingleEvent<int32_t> event;
@@ -418,7 +418,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_2)
     EXPECT_EQ(value, 42);
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_3)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_3)
 {
     int32_t count{};
 
@@ -456,7 +456,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_3)
     EXPECT_EQ(v5, count);
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_4)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_4)
 {
     int32_t count{};
 
@@ -481,7 +481,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_4)
     EXPECT_EQ(results[4], count);
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_5)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_5)
 {
     int32_t count{};
 
@@ -515,7 +515,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_5)
     EXPECT_EQ(count, 3);
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_exception)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_exception)
 {
     int32_t count{};
 
@@ -548,7 +548,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_exception)
     EXPECT_EQ(count, 3);
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_exception2)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_exception2)
 {
     int32_t count{};
 
@@ -575,7 +575,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_exception2)
     EXPECT_EQ(3, count);
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_pauseTask)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_pauseTask)
 {
     tinycoro::Latch latch{2};
 
@@ -606,7 +606,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_pauseTask)
     EXPECT_EQ(i, 6);
 }
 
-TEST(RunInlineTest, RunInline_FunctionalTest_pauseTask_stoped)
+TEST(WaitInlineTest, WaitInline_FunctionalTest_pauseTask_stoped)
 {
     std::stop_source ssource;
 
@@ -648,7 +648,7 @@ TEST(RunInlineTest, RunInline_FunctionalTest_pauseTask_stoped)
     EXPECT_EQ(i, 4);
 }
 
-TEST(RunInlineTest, RunInlineTest_FunctionalTest_with_scheduler)
+TEST(WaitInlineTest, WaitInlineTest_FunctionalTest_with_scheduler)
 {   
     tinycoro::SoftClock clock;
     tinycoro::Scheduler scheduler;
@@ -679,7 +679,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_with_scheduler)
     EXPECT_EQ(fut2.get(), 43);
 }
 
-TEST(RunInlineTest, RunInlineTest_FunctionalTest_sleep)
+TEST(WaitInlineTest, WaitInlineTest_FunctionalTest_sleep)
 {
     tinycoro::SoftClock clock;
     auto deferedTask = [&clock](int32_t r) -> tinycoro::Task<int32_t> {
@@ -695,7 +695,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_sleep)
     
 }
 
-TEST(RunInlineTest, RunInlineTest_FunctionalTest_sleepMulti)
+TEST(WaitInlineTest, WaitInlineTest_FunctionalTest_sleepMulti)
 {
     tinycoro::SoftClock clock;
     auto deferedTask = [&clock](int32_t r) -> tinycoro::Task<int32_t> {
@@ -713,7 +713,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_sleepMulti)
     EXPECT_EQ(r3, 43);
 }
 
-TEST(RunInlineTest, RunInlineTest_FunctionalTest_sleepMulti_dynamic)
+TEST(WaitInlineTest, WaitInlineTest_FunctionalTest_sleepMulti_dynamic)
 {
     tinycoro::SoftClock clock;
 
@@ -734,7 +734,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_sleepMulti_dynamic)
     EXPECT_EQ(results[2], 43);
 }
 
-TEST(RunInlineTest, RunInlineTest_FunctionalTest_pushawait)
+TEST(WaitInlineTest, WaitInlineTest_FunctionalTest_pushawait)
 {
     tinycoro::BufferedChannel<int32_t> channel;
 
@@ -760,7 +760,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_pushawait)
     EXPECT_EQ(fortyTwo, 42);
 }
 
-TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled)
+TEST(WaitInlineTest, WaitInlineTest_FunctionalTest_cancelled)
 {
     tinycoro::SoftClock clock;
 
@@ -789,7 +789,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled)
     event.Set();
 }
 
-TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled_latch)
+TEST(WaitInlineTest, WaitInlineTest_FunctionalTest_cancelled_latch)
 {
     tinycoro::SoftClock clock;
 
@@ -816,7 +816,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled_latch)
     EXPECT_TRUE(r6.has_value());
 }
 
-TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled_dynamic)
+TEST(WaitInlineTest, WaitInlineTest_FunctionalTest_cancelled_dynamic)
 {
     tinycoro::SoftClock clock;
     tinycoro::AutoEvent event;
@@ -853,7 +853,7 @@ TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled_dynamic)
     event.Set();
 }
 
-TEST(RunInlineTest, RunInlineTest_FunctionalTest_cancelled_manual)
+TEST(WaitInlineTest, WaitInlineTest_FunctionalTest_cancelled_manual)
 {
     tinycoro::SoftClock clock;
 

--- a/test/src/YieldValue_test.cpp
+++ b/test/src/YieldValue_test.cpp
@@ -36,7 +36,7 @@ TEST_P(YieldValueTest, YieldValueTest_generator)
         EXPECT_EQ(co_await task, max);
     };
 
-    tinycoro::GetAll(scheduler, consumer(count));
+    tinycoro::AllOf(scheduler, consumer(count));
 }
 
 // Disable code becasue of GCC-11 bug.
@@ -69,7 +69,7 @@ TEST(YieldValueTest, YieldValueTest_variant_yield)
         EXPECT_EQ(std::get<bool>(val), true);
     };
 
-    tinycoro::GetAll(scheduler, runner());
+    tinycoro::AllOf(scheduler, runner());
 }
 
 TEST(YieldValueTest, YieldValueTest_variant_yield_runinline)
@@ -86,7 +86,7 @@ TEST(YieldValueTest, YieldValueTest_variant_yield_runinline)
         EXPECT_EQ(std::get<bool>(val), true);
     };
 
-    tinycoro::RunInline(runner());
+    tinycoro::AllOfInline(runner());
 }
 
 #endif /* !TINY_CORO_GCC_11 */
@@ -99,7 +99,7 @@ TEST(YieldValueTest, YieldValueTest_direct_invoke_runinline)
     };
 
     // in this case co_yield is just ignored
-    auto val = tinycoro::RunInline(func());
+    auto val = tinycoro::AllOfInline(func());
     EXPECT_EQ(*(val.value()), 42);
 }
 
@@ -113,6 +113,6 @@ TEST(YieldValueTest, YieldValueTest_direct_invoke_scheduler)
     };
 
     // in this case co_yield is just ignored
-    auto val = tinycoro::GetAll(scheduler, func());
+    auto val = tinycoro::AllOf(scheduler, func());
     EXPECT_EQ(*(val.value()), 42);
 }


### PR DESCRIPTION
API Cleanup: StopSource + Inline Function Renaming
This PR introduces several improvements and clarifications across the tinycoro API, especially for AllOf and AnyOf utilities.

Summary of Changes
Renamed synchronous functions for clarity
Renamed:
  AllOf(...) →   AllOfInline(...)  // (with scheduler) -> (no scheduler) 
  AnyOf(...) → AnyOfInline(...)

  AllOfAwait(...) →   AllOfInlineAwait(...)
  AnyOfAwait(...) → AnyOfInlineAwait(...)

These now better reflect that they execute inline and are compatible with InlineTask.

Clarified scheduler compatibility
- Scheduler-based versions (e.g. AllOf(scheduler, ...), co_await AllOfAwait(scheduler, ...)) now explicitly require tinycoro::Task.
- Inline variants support both tinycoro::Task and tinycoro::InlineTask.

StopSource usage improvements
- Updated overloads for AnyOf and AnyOfInline to consistently support tinycoro::StopSource where applicable.
- Ensures losing tasks can be cancelled cooperatively when one completes.

README.md updated
- Rewritten sections for AllOf and AnyOf to clearly explain the differences between scheduler-based and inline execution.
- Added important notes about Task vs InlineTask usage and compatibility.

Why This Matters
- These changes aim to make the API:
- Clearer and more intuitive for users.
- Consistent across coroutine and non-coroutine use cases.
- Safer, by avoiding accidental misuse of InlineTask with scheduler-based APIs.