### PR TITLE
intoduce std_atomic_flag

### DIFF
--- a/include/tinycoro/WaitInline.hpp
+++ b/include/tinycoro/WaitInline.hpp
@@ -184,7 +184,7 @@ namespace tinycoro {
                         // most tasks are finished but we have at least
                         // one paused task, so we need to wait on this thread...
                         // Waits until somebody get's notified to resume
-                        event.Wait();
+                        event.WaitAndReset();
                     }
                 }
 
@@ -366,7 +366,7 @@ namespace tinycoro {
                 {
                     // all in pause state or done, so we need to wait on this thread...
                     // Waits until somebody get's notified to resume
-                    event.Wait();
+                    event.WaitAndReset();
                 }
 
                 // clear the vector for the next batch of results


### PR DESCRIPTION
Use std::atomic_flag in AutoResetEvent for guaranteed lock-free behavior

This PR updates the implementation of the AutoResetEvent helper to use std::atomic_flag instead of std::atomic<bool> for the internal state flag.
The main motivation behind this change is to guarantee lock-free behavior across all platforms, as std::atomic_flag is always lock-free by definition.

This change simplifies the internal logic slightly and ensures optimal performance and portability for the event signaling mechanism.