### PR TITLE
remove exception ptr from promise

### DIFF
--- a/include/tinycoro/CoWait.hpp
+++ b/include/tinycoro/CoWait.hpp
@@ -33,9 +33,9 @@ namespace tinycoro {
             template <typename PromiseT, typename FutureStateT>
             [[nodiscard]] static constexpr auto Get() noexcept
             {
-                return [](void* promise, void* futureState) {
+                return [](void* promise, void* futureState, std::exception_ptr ex) {
                     // Call the default task finish handler to set the future.
-                    detail::OnTaskFinish<PromiseT, FutureStateT>(promise, futureState);
+                    detail::OnTaskFinish<PromiseT, FutureStateT>(promise, futureState, std::move(ex));
 
                     // Notify the current awaitable if all the coroutines are completed.
                     auto  p = static_cast<PromiseT*>(promise);

--- a/include/tinycoro/Promise.hpp
+++ b/include/tinycoro/Promise.hpp
@@ -217,7 +217,19 @@ namespace tinycoro {
             // that we can not rely on the base class
             // destructor here, becasue in Finish() we
             // need the value from the derived promise object.
-            ~PromiseT() { this->Finish(); }
+            ~PromiseT() { 
+                if(this->HasException() == false)
+                {
+                    // If there was no exception yet,
+                    // trigger the Finish callback.
+                    //
+                    // Note:
+                    // In case of an exception,
+                    // Finish() is already triggered
+                    // in SchedulableTask::Resume().
+                    this->Finish({});
+                }
+            }
         };
 
         // Inline Promise class.

--- a/include/tinycoro/PromiseBase.hpp
+++ b/include/tinycoro/PromiseBase.hpp
@@ -75,9 +75,6 @@ namespace tinycoro { namespace detail {
         // Todo: consider to rename it to sharedState or so...
         detail::IntrusivePtr<PauseHandlerT> pauseHandler;
 
-        // Gets back the pause state.
-        [[nodiscard]] auto& PauseState() noexcept { return pauseHandler->pauseState; }
-
         // Creates the pause handler shared object
         template <typename... Args>
         auto MakePauseHandler(Args&&... args)
@@ -127,9 +124,9 @@ namespace tinycoro { namespace detail {
             return _currentAwaitable;
         }
 
-        [[nodiscard]] std::suspend_always initial_suspend() const noexcept { return {}; }
+        [[nodiscard]] constexpr std::suspend_always initial_suspend() const noexcept { return {}; }
 
-        [[nodiscard]] FinalAwaiterT final_suspend() const noexcept { return {}; }
+        [[nodiscard]] constexpr FinalAwaiterT final_suspend() const noexcept { return {}; }
 
         constexpr void unhandled_exception() const { std::rethrow_exception(std::current_exception()); }
 

--- a/include/tinycoro/SchedulableTask.hpp
+++ b/include/tinycoro/SchedulableTask.hpp
@@ -66,9 +66,9 @@ namespace tinycoro { namespace detail {
             }
             catch (...)
             {
-                // if there was an exception
-                // save it in the promise.
-                _hdl.promise().exception = std::current_exception();
+                // Calling directly the Finish() function,
+                // if we have an exception.
+                _hdl.promise().Finish(std::current_exception());
             }
 
             // return the corouitne state.
@@ -146,15 +146,15 @@ namespace tinycoro { namespace detail {
     // in order to set the value in the
     // corresponding promise object.
     template <typename PromiseT, typename FutureStateT>
-    void OnTaskFinish(void* self, void* futureStatePtr)
+    void OnTaskFinish(void* self, void* futureStatePtr, std::exception_ptr exception)
     {
         auto promise = static_cast<PromiseT*>(self);
         auto future  = static_cast<FutureStateT*>(futureStatePtr);
 
-        if (promise->exception)
+        if (exception)
         {
             // if we had an exception we just set it
-            future->set_exception(promise->exception);
+            future->set_exception(std::move(exception));
         }
         else
         {

--- a/include/tinycoro/TaskResumer.hpp
+++ b/include/tinycoro/TaskResumer.hpp
@@ -76,16 +76,15 @@ namespace tinycoro { namespace detail {
             {
                 auto& promise = handle.promise();
 
-                if constexpr (requires { promise.exception; })
+                if constexpr (requires { {promise.HasException()} -> std::same_as<bool>; })
                 {
-                    // exception is not supported by InlinePromise
-                    if (promise.exception)
+                    if(promise.HasException())
                     {
                         // if there was an unhandled
-                        // exception the task is done
+                        // exception, the task is done
                         return ETaskResumeState::DONE;
                     }
-                }
+                } 
 
                 const auto& pauseHandler = promise.pauseHandler;
                 const auto& stopSource   = promise.stopSource;

--- a/test/src/AtomicPtrStack_test.cpp
+++ b/test/src/AtomicPtrStack_test.cpp
@@ -23,6 +23,10 @@ TEST_F(AtomicPtrStackTest, AtomicPtrStackTest_push)
     stack.try_push(&node3);
 
     EXPECT_FALSE(stack.empty());
+
+    std::cout << "task size: " << sizeof(tinycoro::detail::Promise<void>) << '\n';
+    std::cout << "inline task size: " << sizeof(tinycoro::detail::InlinePromise<void>) << '\n';
+
 }
 
 TEST_F(AtomicPtrStackTest, AtomicPtrStackTest_push_steal)

--- a/test/src/PauseHandler_test.cpp
+++ b/test/src/PauseHandler_test.cpp
@@ -141,6 +141,28 @@ TEST(PauseHandlerTest, PauseHandlerTest_MakeCancellable_noninitial_cancellable)
     EXPECT_TRUE(pauseHandler.IsCancellable());
 }
 
+TEST(PauseHandlerTest, PauseHandlerTest_ExceptionThrowned)
+{
+    tinycoro::PauseHandler pauseHandler{[]{}, tinycoro::noninitial_cancellable_t::value};
+    
+    EXPECT_FALSE(pauseHandler.HasException());
+    pauseHandler.Resume();
+    EXPECT_FALSE(pauseHandler.HasException());
+
+    // set the exception
+    pauseHandler.MarkException();
+
+    EXPECT_FALSE(pauseHandler.IsCancellable());
+    EXPECT_FALSE(pauseHandler.IsPaused());
+    EXPECT_TRUE(pauseHandler.HasException());
+
+    pauseHandler.Resume();
+    EXPECT_TRUE(pauseHandler.HasException());
+
+    EXPECT_FALSE(pauseHandler.IsCancellable());
+    EXPECT_FALSE(pauseHandler.IsPaused());
+}
+
 struct Context_PauseHandlerMock
 {
     MOCK_METHOD(std::function<void()>, Pause, ());


### PR DESCRIPTION
Remove std::exception_ptr from promise (Shrinks promise object)

Summary:
This PR removes the std::exception_ptr from the coroutine promise type and introduces a more direct exception propagation mechanism. The key benefit of this change is that the promise object becomes one pointer smaller, which leads to reduced memory footprint and potentially better cache locality.

Changes:
- Removed the std::exception_ptr member from the promise implementation.
- Replaced it with a simpler mechanism for storing exceptions directly.
- Extend Finish callback with std::exception_ptr.
- Adjusted awaiter logic to propagate exceptions without relying on exception_ptr.