### PR TITLE
Add TimeoutAwait wrapper for timed coroutine suspension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1193,10 +1193,10 @@ This makes timeout handling explicit — you can directly check if a timeout occ
 ```cpp
 // Waits for 100ms.
 auto result = co_await tinycoro::TimeoutAwait{clock, someAwaitable(), 100ms};
-if (!result) {
-    // Timeout occurred
-} else {
+if (result) {
     // result.value() contains the awaitable’s result
+} else {
+    // Timeout occurred
 }
 ```
 #### Behavior
@@ -1215,10 +1215,10 @@ tinycoro::Barrier barrier{3};
 auto task = [&]() -> tinycoro::Task<> {
     // Wait on barrier for max 10 milliseconds
     auto res = co_await tinycoro::TimeoutAwait{clock, barrier.Wait(), 10ms};
-    if (!res) {
-        std::println("Timeout!");
-    } else {
+    if (res) {
         std::println("Barrier passed!");
+    } else {
+        std::println("Timeout!");
     }
 };
 

--- a/README.md
+++ b/README.md
@@ -1168,7 +1168,7 @@ It works with both **relative durations** (`wait_for`-style) and **absolute time
 #### Syntax
 
 ```cpp
-auto resultOptional = tinycoro::TimeoutAwait{clock, awaitable, timeout}
+std::optional<T> result = tinycoro::TimeoutAwait{clock, originalAwaitable, timeout}
 ```
 
 #### Parameters
@@ -1176,7 +1176,7 @@ auto resultOptional = tinycoro::TimeoutAwait{clock, awaitable, timeout}
 | Parameter  | Type                                                                                 | Description                                                                 |
 |------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | `clock`    | `tinycoro::SoftClock` or compatible clock                                            | The clock used for scheduling the timeout and handling cancellation.        |
-| `awaitable`| Any cancellable awaitable (satisfying `concepts::IsCancellableAwait`)                 | The operation to wait on with a timeout.                                    |
+| `originalAwaitable`| Any cancellable awaitable (satisfying `concepts::IsCancellableAwait`)                 | The operation to wait on with a timeout.                                    |
 | `timeout`  | `std::chrono::duration` or `std::chrono::time_point`   | The timeout limit.
 
 #### Return Value

--- a/example/CustomAwaiter.h
+++ b/example/CustomAwaiter.h
@@ -26,7 +26,7 @@ struct CustomAwaiter
             self->_userData++;
 
             // resume the coroutine (you need to make them exception safe)
-            self->_resumeTask();
+            self->_resumeTask(tinycoro::ENotifyPolicy::RESUME);
         };
 
         AsyncCallbackAPIvoid(cb, this);
@@ -36,7 +36,7 @@ struct CustomAwaiter
 
     int32_t _userData{41};
 
-    std::function<void()> _resumeTask;
+    tinycoro::PauseHandlerCallbackT _resumeTask;
 };
 
 void Example_CustomAwaiter(auto& scheduler)

--- a/include/tinycoro/AutoEvent.hpp
+++ b/include/tinycoro/AutoEvent.hpp
@@ -272,9 +272,11 @@ namespace tinycoro {
                 return true;
             }
 
-            constexpr auto await_resume() noexcept { }
+            constexpr void await_resume() const noexcept { }
 
-            void Notify() const noexcept { _event.Notify(); }
+            void Notify() const noexcept { _event.Notify(ENotifyPolicy::RESUME); }
+            
+            void NotifyToDestroy() const noexcept { _event.Notify(ENotifyPolicy::DESTROY); }
 
             bool Cancel() noexcept { return _autoEvent.Cancel(this); }
 

--- a/include/tinycoro/Barrier.hpp
+++ b/include/tinycoro/Barrier.hpp
@@ -99,6 +99,7 @@ namespace tinycoro {
 
             bool Cancel() noexcept { return _barrier.Cancel(this); };
 
+        private:
             void PutOnPause(auto parentCoro) { _event.Set(context::PauseTask(parentCoro)); }
 
             void ResumeFromPause(auto parentCoro)
@@ -107,7 +108,6 @@ namespace tinycoro {
                 context::UnpauseTask(parentCoro);
             }
 
-        private:
             BarrierT& _barrier;
             EventT    _event;
 

--- a/include/tinycoro/Barrier.hpp
+++ b/include/tinycoro/Barrier.hpp
@@ -93,10 +93,9 @@ namespace tinycoro {
 
             constexpr void await_resume() const noexcept { }
 
-            void Notify() const noexcept
-            {
-                _event.Notify();
-            }
+            void Notify() const noexcept { _event.Notify(ENotifyPolicy::RESUME); }
+            
+            void NotifyToDestroy() const noexcept { _event.Notify(ENotifyPolicy::DESTROY); }
 
             bool Cancel() noexcept { return _barrier.Cancel(this); };
 

--- a/include/tinycoro/CallOnce.hpp
+++ b/include/tinycoro/CallOnce.hpp
@@ -1,0 +1,43 @@
+#ifndef TINY_CORO_CALL_ONCE_HPP
+#define TINY_CORO_CALL_ONCE_HPP
+
+#include <concepts>
+#include <functional>
+#include <atomic>
+
+namespace tinycoro { namespace detail {
+
+    // Calls the provided function exactly once across all threads that call this function.
+    // Uses an atomic flag to ensure the function is only invoked once.
+    //
+    // Parameters:
+    //   - flag: An atomic flag (must support test_and_set(memory_order)) shared across threads.
+    //   - memoryOrder: The memory ordering to use for the test_and_set operation.
+    //                  Should be at least std::memory_order_acquire; use std::memory_order_acq_rel
+    //                  if this thread is expected to perform initialization.
+    //   - func: The callable object to be invoked once.
+    //   - args: Arguments to be forwarded to the callable.
+    //
+    // Returns:
+    //   - true if this thread successfully executed the callable (i.e., was the first to set the flag).
+    //   - false if another thread had already set the flag and invoked the callable.
+    template <typename FlagT, typename FuncT, typename... Args>
+        requires std::invocable<FuncT, Args...>
+    constexpr bool CallOnce(FlagT& flag, std::memory_order memoryOrder, FuncT&& func, Args&&... args)
+    {
+        // Atomically test and set the flag using the provided memory order.
+        // If the flag was not previously set (i.e., returns false), invoke the callable.
+        if (flag.test_and_set(memoryOrder) == false)
+        {
+            // First thread to set the flag: invoke the function with forwarded arguments.
+            std::invoke(std::forward<FuncT>(func), std::forward<Args>(args)...);
+            return true;
+        }
+
+        // Another thread has already set the flag; do nothing.
+        return false;
+    }
+
+}} // namespace tinycoro::detail
+
+#endif // TINY_CORO_CALL_ONCE_HPP

--- a/include/tinycoro/Cancellable.hpp
+++ b/include/tinycoro/Cancellable.hpp
@@ -65,7 +65,9 @@ namespace tinycoro {
                         // set the cancellable flag,
                         // we still need to notify the awaiter
                         // to trigger further actions.
-                        _awaiter.Notify();
+                        //
+                        // e.g. await_resume() will be not called.
+                        _awaiter.NotifyToDestroy();
                     }
                 });
             }

--- a/include/tinycoro/CoWait.hpp
+++ b/include/tinycoro/CoWait.hpp
@@ -89,7 +89,7 @@ namespace tinycoro {
             friend struct AsyncAwaitOnFinishWrapper<AsyncAwaiterT*>;
 
             AsyncAwaiterT(SchedulerT& scheduler, EventT event, Args&&... args)
-            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, sizeof...(Args)}
+            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, std::move(event), sizeof...(Args)}
             , _coroutineTasks(std::forward<Args>(args)...)
             {
             }
@@ -119,7 +119,7 @@ namespace tinycoro {
             friend struct AsyncAwaitOnFinishWrapper<AsyncAwaiterT*>;
 
             AsyncAwaiterT(SchedulerT& scheduler, EventT event, ContainerT&& container)
-            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, std::size(container)}
+            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, std::move(event), std::size(container)}
             , _container{std::forward<ContainerT>(container)}
             {
             }
@@ -153,7 +153,7 @@ namespace tinycoro {
             friend struct AsyncAwaitOnFinishWrapper<AsyncAnyOfAwaiterT*>;
 
             AsyncAnyOfAwaiterT(SchedulerT& scheduler, StopSourceT stopSource, EventT event, Args&&... args)
-            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, sizeof...(Args)}
+            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, std::move(event), sizeof...(Args)}
             , _stopSource{std::move(stopSource)}
             , _coroutineTasks(std::forward<Args>(args)...)
             {
@@ -185,7 +185,7 @@ namespace tinycoro {
             friend struct AsyncAwaitOnFinishWrapper<AsyncAnyOfAwaiterT*>;
 
             AsyncAnyOfAwaiterT(SchedulerT& scheduler, StopSourceT stopSource, EventT event, ContainerT&& container)
-            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, event, std::size(container)}
+            : AsyncAwaiterBase<SchedulerT, EventT, FuturesT>{scheduler, std::move(event), std::size(container)}
             , _stopSource{std::move(stopSource)}
             , _container{std::forward<ContainerT>(container)}
             {

--- a/include/tinycoro/Latch.hpp
+++ b/include/tinycoro/Latch.hpp
@@ -123,7 +123,9 @@ namespace tinycoro {
 
             constexpr void await_resume() const noexcept { }
 
-            void Notify() const noexcept { _event.Notify(); }
+            void Notify() const noexcept { _event.Notify(ENotifyPolicy::RESUME); }
+            
+            void NotifyToDestroy() const noexcept { _event.Notify(ENotifyPolicy::DESTROY); }
 
             bool Cancel() noexcept { return _latch.Cancel(this); }
 

--- a/include/tinycoro/ManualEvent.hpp
+++ b/include/tinycoro/ManualEvent.hpp
@@ -195,9 +195,11 @@ namespace tinycoro {
                 return true;
             }
 
-            constexpr auto await_resume() noexcept { }
+            constexpr void await_resume() const noexcept { }
 
-            void Notify() const noexcept { _event.Notify(); }
+            void Notify() const noexcept { _event.Notify(ENotifyPolicy::RESUME); }
+            
+            void NotifyToDestroy() const noexcept { _event.Notify(ENotifyPolicy::DESTROY); }
 
             bool Cancel() noexcept { return _manualEvent.Cancel(this); }
 

--- a/include/tinycoro/Promise.hpp
+++ b/include/tinycoro/Promise.hpp
@@ -18,7 +18,7 @@ namespace tinycoro {
 
         struct FinalAwaiter
         {
-            [[nodiscard]] bool await_ready() const noexcept { return false; }
+            [[nodiscard]] constexpr bool await_ready() const noexcept { return false; }
 
             [[nodiscard]] std::coroutine_handle<> await_suspend(auto hdl) noexcept
             {
@@ -39,7 +39,7 @@ namespace tinycoro {
                 return std::noop_coroutine();
             }
 
-            void await_resume() const noexcept { }
+            constexpr void await_resume() const noexcept { }
         };
 
         template <typename... Args>

--- a/include/tinycoro/SchedulerWorker.hpp
+++ b/include/tinycoro/SchedulerWorker.hpp
@@ -206,7 +206,7 @@ namespace tinycoro { namespace detail {
         // It relays on a task pointer address
         PauseHandlerCallbackT GeneratePauseResume(auto promisePtr) noexcept
         {
-            return [this, promisePtr]() {
+            return [this, promisePtr](ENotifyPolicy policy) {
                 if (_stopToken.stop_requested() == false)
                 {
                     auto expected = promisePtr->pauseState.load(std::memory_order_relaxed);
@@ -236,9 +236,10 @@ namespace tinycoro { namespace detail {
                     // push back to the queue
                     // for resumption
                     Task_t task{promisePtr};
-                    if (_stopToken.stop_requested() == false)
+                    if (_stopToken.stop_requested() == false && policy != ENotifyPolicy::DESTROY)
                     {
-                        // no stop was requested
+                        // no stop was requested,
+                        // and no immediate destroy policy.
                         if (_sharedTasks.try_push(std::move(task)))
                         {
                             // push succeed

--- a/include/tinycoro/Semaphore.hpp
+++ b/include/tinycoro/Semaphore.hpp
@@ -110,10 +110,7 @@ namespace tinycoro {
                 return true;
             }
 
-            [[nodiscard]] constexpr auto await_resume() noexcept
-            {
-                return ReleaseGuard{_semaphore};
-            }
+            [[nodiscard]] constexpr auto await_resume() noexcept { return ReleaseGuard{_semaphore}; }
 
             void Notify() const noexcept { _event.Notify(); }
 

--- a/include/tinycoro/TaskAwaiter.hpp
+++ b/include/tinycoro/TaskAwaiter.hpp
@@ -50,7 +50,7 @@ namespace tinycoro {
         AwaiterValue() = default;
 
     public:
-        constexpr void await_resume() noexcept { }
+        constexpr void await_resume() const noexcept { }
     };
 
 } // namespace tinycoro

--- a/include/tinycoro/TimeoutAwait.hpp
+++ b/include/tinycoro/TimeoutAwait.hpp
@@ -96,7 +96,7 @@ namespace tinycoro {
                 //
                 // We return with an std::optional<VoidType> 
                 _awaiter.await_resume();
-                return optional_t{{}};
+                return optional_t{std::in_place_t{}};
             }
             else
             {

--- a/include/tinycoro/TimeoutAwait.hpp
+++ b/include/tinycoro/TimeoutAwait.hpp
@@ -1,0 +1,135 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024 Tamas Kovacs
+//  Licensed under the MIT License – see LICENSE.txt for details.
+// -----------------------------------------------------------------------------
+
+#ifndef TINY_CORO_TIMEOUT_AWAIT_HPP
+#define TINY_CORO_TIMEOUT_AWAIT_HPP
+
+#include <cassert>
+
+#include "Common.hpp"
+
+namespace tinycoro {
+
+    // TimeoutAwait wraps a cancellable awaiter and augments it with timeout support.
+    // It registers a cancellation callback with the given clock that will request_stop()
+    // if the awaited operation does not complete within the specified time.
+    //
+    // If the operation completes before the timeout, the clock's cancel token is cancelled.
+    // Otherwise, the clock triggers cancellation, and the coroutine resumes accordingly.
+    //
+    // Template parameters:
+    // - ClockT: clock type providing timeout scheduling and cancellation support.
+    // - AwaiterT: an awaitable type satisfying concepts::IsCancellableAwait.
+    // - TimeT: timeout specification, e.g., a duration or time point.
+    template <typename ClockT, concepts::IsCancellableAwait AwaiterT, typename TimeT>
+    struct TimeoutAwait
+    {
+        TimeoutAwait(ClockT& clock, AwaiterT&& awaiter, TimeT time)
+        : _awaiter{awaiter}
+        , _clock{clock}
+        , _time{time}
+        {
+        }
+
+        constexpr auto await_ready() noexcept
+        {
+            // delegate the call directly
+            // to the awaiter.
+            return _awaiter.await_ready();
+        }
+
+        constexpr auto await_suspend(auto parentCoro)
+        {
+            auto suspend = _awaiter.await_suspend(parentCoro);
+
+            if (suspend)
+            {
+                // set the event callback for the clock
+                // which is intented to force resume the awaiter
+                // after the timeout was reached.
+                auto cancellCallback = [this]() noexcept {
+
+                    // try to cancel the awaiter.
+                    if(_awaiter.Cancel())
+                    {
+                        _awaiterCancelled.store(true, std::memory_order::release);
+                        
+                        // At this point the awaiter is already
+                        // cancelled, but we still force the resumption,
+                        // in order to notify the awaiter.
+                        _awaiter.Notify();
+                    }
+                };
+
+                // initialize the cancel token for the event
+                _clockCancelToken = _clock.RegisterWithCancellation(cancellCallback, _time);
+            }
+
+            return suspend;
+        }
+
+        constexpr auto await_resume() noexcept
+        {
+            using return_t   = decltype(std::declval<AwaiterT>().await_resume());
+            using optional_t = detail::TaskResult_t<return_t>;
+            
+            // We can try to cancel the clock callback.
+            // We will resume the coroutine anyway here.
+            _clockCancelToken.TryCancel();
+
+            // check if the awaiter is cancelled,
+            // by the clock event. See await_suspend().
+            if(_awaiterCancelled.load(std::memory_order::acquire))
+            {
+                // The cancellation succeeded,
+                // we return an empty optional
+                return optional_t{};
+            }
+
+            // No cancellation occured.
+            // Picking up the return value...
+            if constexpr (std::same_as<return_t, void>)
+            {
+                // Special return value handling in case of void.
+                //
+                // We return with an std::optional<VoidType> 
+                _awaiter.await_resume();
+                return optional_t{{}};
+            }
+            else
+            {
+                // Wrapp the await_resume result
+                // in a std::optional object,
+                // and return it to the caller.
+                return optional_t{_awaiter.await_resume()};
+            }
+        }
+
+    private:
+        // The wrapped awaiter object.
+        AwaiterT& _awaiter;
+
+        // The clock reference, which
+        // schedule the "force resume" callback event depending
+        // on the timeout.
+        ClockT& _clock;
+
+        // Delayed initialization.
+        //
+        // See real initialization in await_suspend().
+        ClockT::cancelToken_t _clockCancelToken{};
+
+        // _time could be a timepoint
+        // or a duration which will be passed
+        // together with the callback event to the clock.
+        TimeT _time;
+
+        // Flag to indicate if we could cancel the awaiter.
+        std::atomic<bool> _awaiterCancelled{false};
+    };
+
+} // namespace tinycoro
+
+#endif // TINY_CORO_TIMEOUT_AWAIT_HPP

--- a/include/tinycoro/UnbufferedChannel.hpp
+++ b/include/tinycoro/UnbufferedChannel.hpp
@@ -39,6 +39,8 @@ namespace tinycoro {
             using cleanupFunction_t = std::function<void(ValueT&)>;
 
         public:
+            using value_type = ValueT;
+
             // default constructor
             UnbufferedChannel(cleanupFunction_t cleanupFunc = {})
             : _cleanupFunction{std::move(cleanupFunc)}
@@ -125,7 +127,7 @@ namespace tinycoro {
                 // prepare a special event for notification
                 detail::PauseCallbackEvent event;
 
-                event.Set([&latch] {
+                event.Set([&latch](auto) {
                     latch.count_down();
                 });
 
@@ -378,11 +380,9 @@ namespace tinycoro {
                 return EChannelOpStatus::CLOSED;
             }
 
-            void Notify() const noexcept
-            {
-                // Notify scheduler to put coroutine back on CPU
-                _event.Notify();
-            }
+            void Notify() const noexcept { _event.Notify(ENotifyPolicy::RESUME); }
+            
+            void NotifyToDestroy() const noexcept { _event.Notify(ENotifyPolicy::DESTROY); }
 
             bool Cancel() noexcept { return _channel.Cancel(this); }
 
@@ -484,11 +484,9 @@ namespace tinycoro {
                 return {_value, _lastElement};
             }
 
-            void Notify() const noexcept
-            {
-                // Notify scheduler to put coroutine back on CPU
-                _event.Notify();
-            }
+           void Notify() const noexcept { _event.Notify(ENotifyPolicy::RESUME); }
+            
+            void NotifyToDestroy() const noexcept { _event.Notify(ENotifyPolicy::DESTROY); }
 
             bool Cancel() noexcept { return _channel.Cancel(this); }
 
@@ -549,11 +547,9 @@ namespace tinycoro {
 
             [[nodiscard]] auto value() const noexcept { return _listenersCount; }
 
-            void Notify() const noexcept
-            {
-                // Notify scheduler to put coroutine back on CPU
-                _event.Notify();
-            }
+           void Notify() const noexcept { _event.Notify(ENotifyPolicy::RESUME); }
+            
+            void NotifyToDestroy() const noexcept { _event.Notify(ENotifyPolicy::DESTROY); }
 
             bool Cancel() noexcept { return _channel.Cancel(this); }
 

--- a/include/tinycoro/WaitInline.hpp
+++ b/include/tinycoro/WaitInline.hpp
@@ -37,7 +37,7 @@ namespace tinycoro {
         template <typename TaskT, typename EventT, typename StopTokenT>
         void SetPauseResumerCallback(TaskT& task, EventT& event, StopTokenT stopToken)
         {
-            auto pauseResumerCallback = [&task, &event, stopToken] {
+            auto pauseResumerCallback = [&task, &event, stopToken] ([[maybe_unused]] ENotifyPolicy policy) {
                 auto pauseHandler = task.GetPauseHandler();
 
                 // checking if the task is cancelled

--- a/include/tinycoro/tinycoro_all.h
+++ b/include/tinycoro/tinycoro_all.h
@@ -32,5 +32,6 @@
 #include "UnbufferedChannel.hpp"
 #include "SoftClock.hpp"
 #include "Cancellable.hpp"
+#include "TimeoutAwait.hpp"
 
 #endif // TINY_CORO_TINY_CORO_ALL_H

--- a/test/src/AsyncCallbackAwaiter_CStyle_test.cpp
+++ b/test/src/AsyncCallbackAwaiter_CStyle_test.cpp
@@ -17,7 +17,7 @@ struct AsyncCallbackAwaiter_CStyleTest : public testing::Test
 
     AsyncCallbackAwaiter_CStyleTest()
     {
-        hdl.promise().pauseHandler.emplace([this]() { pauseHandlerCalled = true; });
+        hdl.promise().pauseHandler.emplace([this]([[maybe_unused]] auto policy) { pauseHandlerCalled = true; });
     }
 
     bool pauseHandlerCalled{false};
@@ -52,10 +52,7 @@ void AsyncCallbackAwaiterTest1(const bool& pauseHandlerCalled, auto hdl)
     EXPECT_FALSE(awaiter.await_ready());
     awaiter.await_suspend(hdl);
 
-    if constexpr (!std::same_as<decltype(awaiter.await_resume()), void>)
-    {
-        EXPECT_TRUE(false) << "await_resume return not void!";
-    }
+    EXPECT_TRUE((std::same_as<decltype(awaiter.await_resume()), void>)) << "await_resume return not void!";
 
     EXPECT_EQ(uData.data, true);
     EXPECT_TRUE(pauseHandlerCalled);
@@ -83,10 +80,7 @@ void AsyncCallbackAwaiterTest2(const bool& pauseHandlerCalled, auto hdl)
     EXPECT_FALSE(awaiter.await_ready());
     awaiter.await_suspend(hdl);
 
-    if constexpr (!std::same_as<decltype(awaiter.await_resume()), int32_t&&>)
-    {
-        EXPECT_TRUE(false) << "await_resume return not int32_t&&!";
-    }
+    EXPECT_TRUE((std::same_as<decltype(awaiter.await_resume()), int32_t>)) << "await_resume return not int32_t!";
 
     EXPECT_EQ(awaiter.await_resume(), 44);
     EXPECT_EQ(uData, 42);

--- a/test/src/AsyncCallbackAwaiter_test.cpp
+++ b/test/src/AsyncCallbackAwaiter_test.cpp
@@ -17,7 +17,7 @@ struct AsyncCallbackAwaiterTest : public testing::Test
 
     AsyncCallbackAwaiterTest()
     {
-        hdl.promise().pauseHandler.emplace([this]() { pauseHandlerCalled = true; });
+        hdl.promise().pauseHandler.emplace([this]([[maybe_unused]] tinycoro::ENotifyPolicy policy) { pauseHandlerCalled = true; });
     }
 
     bool pauseHandlerCalled{false};

--- a/test/src/AtomicPtrStack_test.cpp
+++ b/test/src/AtomicPtrStack_test.cpp
@@ -23,10 +23,6 @@ TEST_F(AtomicPtrStackTest, AtomicPtrStackTest_push)
     stack.try_push(&node3);
 
     EXPECT_FALSE(stack.empty());
-
-    std::cout << "task size: " << sizeof(tinycoro::detail::Promise<void>) << '\n';
-    std::cout << "inline task size: " << sizeof(tinycoro::detail::InlinePromise<void>) << '\n';
-
 }
 
 TEST_F(AtomicPtrStackTest, AtomicPtrStackTest_push_steal)

--- a/test/src/Barrier_test.cpp
+++ b/test/src/Barrier_test.cpp
@@ -111,7 +111,7 @@ class BarrierAwaiterMock : public tinycoro::detail::BarrierAwaiter<BarrierAwaite
 
 public:
     BarrierAwaiterMock(BarrierT& b, EventT e, auto p)
-    : BaseT{*this, e, p}
+    : BaseT{*this, std::move(e), p}
     , barrier{b}
     {
     }
@@ -141,7 +141,7 @@ TEST(BarrierTest, BarrierTest_arriveAndWait)
 
     auto awaiter = barrier.ArriveAndWait();
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
 
     EXPECT_TRUE(awaiter.await_suspend(hdl));
 
@@ -157,7 +157,7 @@ TEST(BarrierTest, BarrierTest_await_suspend)
 
     auto awaiter = barrier.ArriveAndWait();
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
 
     EXPECT_FALSE(awaiter.await_suspend(hdl));
 }
@@ -170,7 +170,7 @@ TEST(BarrierTest, BarrierTest_await_suspend_dropWait)
 
     auto awaiter = barrier.ArriveDropAndWait();
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
 
     EXPECT_FALSE(awaiter.await_suspend(hdl));
 }
@@ -220,7 +220,7 @@ TEST(BarrierTest, BarrierTest_arriveAndWait_after)
 
     EXPECT_FALSE(awaiter.await_ready());
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
     EXPECT_FALSE(awaiter.await_suspend(hdl));
 }
 
@@ -249,7 +249,7 @@ TEST(BarrierTest, BarrierTest_await_ready_and_suspend)
 
     EXPECT_FALSE(awaiter.await_ready());
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(awaiter.await_suspend(hdl));
 }
 
@@ -263,7 +263,7 @@ TEST(BarrierTest, BarrierTest_await_ready_and_suspend_ready)
 
     EXPECT_FALSE(awaiter.await_ready());
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
     EXPECT_FALSE(awaiter.await_suspend(hdl));
 }
 
@@ -277,7 +277,7 @@ TEST(BarrierTest, BarrierTest_notifyAndComplition)
 
     auto awaiter = barrier.Wait();
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
 
     EXPECT_TRUE(awaiter.await_suspend(hdl));
 
@@ -709,4 +709,60 @@ TEST(BarrierTest, BarrierTest_completionException)
 
     EXPECT_THROW(tinycoro::AllOf(scheduler, task(), task()), std::runtime_error);
     EXPECT_EQ(fullyCompleted, 1);
+}
+
+TEST_P(BarrierTest, BarrierTest_timeout)
+{
+    tinycoro::Scheduler scheduler;
+    tinycoro::SoftClock clock;
+
+    auto count = GetParam();
+
+    tinycoro::Barrier barrier{count};
+
+    std::atomic<decltype(count)> cc = count;
+
+    auto consumer = [&]()->tinycoro::Task<> {
+        co_await tinycoro::TimeoutAwait{clock, barrier.Wait(), 10ms};
+        cc--;
+    };
+
+    std::vector<tinycoro::Task<>> tasks;
+    tasks.reserve(count);
+    for([[maybe_unused]] auto _ : std::ranges::views::iota(0u, count))
+    {
+        tasks.emplace_back(consumer());
+    }
+
+    tinycoro::AllOf(scheduler, std::move(tasks));
+
+    EXPECT_EQ(cc, 0);
+}
+
+TEST_P(BarrierTest, BarrierTest_timeout_race)
+{
+    tinycoro::Scheduler scheduler;
+    tinycoro::SoftClock clock;
+
+    auto count = GetParam();
+
+    tinycoro::Barrier barrier{std::max((count / 2), 1ul)};
+
+    std::atomic<decltype(count)> cc = count;
+
+    auto consumer = [&]()->tinycoro::Task<> {
+        co_await tinycoro::TimeoutAwait{clock, barrier.ArriveAndWait(), 10ms};
+        cc--;
+    };
+
+    std::vector<tinycoro::Task<>> tasks;
+    tasks.reserve(count);
+    for([[maybe_unused]] auto _ : std::ranges::views::iota(0u, count))
+    {
+        tasks.emplace_back(consumer());
+    }
+
+    tinycoro::AllOf(scheduler, std::move(tasks));
+
+    EXPECT_EQ(cc, 0);
 }

--- a/test/src/BufferedChannel_test.cpp
+++ b/test/src/BufferedChannel_test.cpp
@@ -68,7 +68,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_open_push_await_suspend)
     int32_t val;
     auto    awaiter1 = channel.PopWait(val);
 
-    auto hdl1 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl1 = tinycoro::test::MakeCoroutineHdl();
 
     EXPECT_FALSE(awaiter1.await_suspend(hdl1));
     EXPECT_TRUE(channel.IsOpen());
@@ -76,7 +76,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_open_push_await_suspend)
 
     auto awaiter2 = channel.PopWait(val);
 
-    auto hdl2 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl2 = tinycoro::test::MakeCoroutineHdl();
 
     EXPECT_FALSE(awaiter2.await_suspend(hdl2));
     EXPECT_FALSE(channel.IsOpen()); // channel need to be closed
@@ -100,7 +100,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_open_emplace_await_suspend)
     int32_t val;
     auto    awaiter1 = channel.PopWait(val);
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
 
     EXPECT_FALSE(awaiter1.await_suspend(hdl));
     EXPECT_TRUE(channel.IsOpen());
@@ -108,7 +108,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_open_emplace_await_suspend)
 
     auto awaiter2 = channel.PopWait(val);
 
-    auto hdl2 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl2 = tinycoro::test::MakeCoroutineHdl();
 
     EXPECT_FALSE(awaiter2.await_suspend(hdl2));
     EXPECT_FALSE(channel.IsOpen()); // channel need to be closed
@@ -270,7 +270,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_await_ready_listener_closed_after)
 
     channel.Close();
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
     EXPECT_FALSE(listenerAwaiter.await_suspend(hdl));
 }
 
@@ -364,17 +364,17 @@ TEST_P(BufferedChannelListenerTest, BufferedChannelTest_await_ready_with_listene
 
     tinycoro::BufferedChannel<int32_t> channel;
 
-    auto    hdl1 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto    hdl1 = tinycoro::test::MakeCoroutineHdl();
     int32_t val1{};
     auto    awaiter1 = channel.PopWait(val1);
     EXPECT_TRUE(awaiter1.await_suspend(hdl1));
 
-    auto    hdl2 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto    hdl2 = tinycoro::test::MakeCoroutineHdl();
     int32_t val2{};
     auto    awaiter2 = channel.PopWait(val2);
     EXPECT_TRUE(awaiter2.await_suspend(hdl2));
 
-    auto    hdl3 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto    hdl3 = tinycoro::test::MakeCoroutineHdl();
     int32_t val3{};
     auto    awaiter3 = channel.PopWait(val3);
     EXPECT_TRUE(awaiter3.await_suspend(hdl3));
@@ -395,24 +395,24 @@ TEST_P(BufferedChannelListenerTest, BufferedChannelTest_await_suspend_with_liste
 
     tinycoro::BufferedChannel<int32_t> channel;
 
-    auto    hdl1 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto    hdl1 = tinycoro::test::MakeCoroutineHdl();
     int32_t val1{};
     auto    awaiter1 = channel.PopWait(val1);
     EXPECT_TRUE(awaiter1.await_suspend(hdl1));
 
-    auto    hdl2 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto    hdl2 = tinycoro::test::MakeCoroutineHdl();
     int32_t val2{};
     auto    awaiter2 = channel.PopWait(val2);
     EXPECT_TRUE(awaiter2.await_suspend(hdl2));
 
-    auto    hdl3 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto    hdl3 = tinycoro::test::MakeCoroutineHdl();
     int32_t val3{};
     auto    awaiter3 = channel.PopWait(val3);
     EXPECT_TRUE(awaiter3.await_suspend(hdl3));
 
     auto listenerAwaiter = channel.WaitForListeners(count);
 
-    auto listenerHdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto listenerHdl = tinycoro::test::MakeCoroutineHdl();
 
     // we have already 3 awaiter so listeners are listening
     EXPECT_NE(listenerAwaiter.await_suspend(listenerHdl), ready);
@@ -444,7 +444,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_await_suspend)
     auto    awaiter = channel.PopWait(val);
 
     bool pauseResumeCalled{false};
-    auto hdl = tinycoro::test::MakeCoroutineHdl([&pauseResumeCalled] { pauseResumeCalled = true; });
+    auto hdl = tinycoro::test::MakeCoroutineHdl([&pauseResumeCalled](auto) { pauseResumeCalled = true; });
 
     EXPECT_TRUE(awaiter.await_suspend(hdl));
     EXPECT_EQ(val, 0);
@@ -465,7 +465,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_await_resume)
     auto    awaiter = channel.PopWait(val);
 
     bool pauseResumeCalled{false};
-    auto hdl = tinycoro::test::MakeCoroutineHdl([&pauseResumeCalled] { pauseResumeCalled = true; });
+    auto hdl = tinycoro::test::MakeCoroutineHdl([&pauseResumeCalled](auto) { pauseResumeCalled = true; });
 
     EXPECT_TRUE(awaiter.await_suspend(hdl));
     EXPECT_EQ(val, 0);
@@ -525,7 +525,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_await_resume_push_close)
     int32_t val{};
     auto    awaiter = channel.PopWait(val);
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
 
     channel.Push(42);
 
@@ -635,7 +635,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_await_resume_close)
     int32_t val{};
     auto    awaiter = channel.PopWait(val);
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
 
     EXPECT_TRUE(awaiter.await_suspend(hdl));
 
@@ -661,7 +661,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_await_resume_multi)
         auto    awaiter = channel.PopWait(val);
 
         bool pauseResumeCalled{false};
-        auto hdl = tinycoro::test::MakeCoroutineHdl([&pauseResumeCalled] { pauseResumeCalled = true; });
+        auto hdl = tinycoro::test::MakeCoroutineHdl([&pauseResumeCalled](auto) { pauseResumeCalled = true; });
 
         EXPECT_FALSE(awaiter.await_suspend(hdl));
 
@@ -709,7 +709,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_push_await_close_after)
 
     channel.Close();
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
     EXPECT_FALSE(pushAwaiter.await_suspend(hdl));
 
     EXPECT_EQ(tinycoro::EChannelOpStatus::CLOSED, pushAwaiter.await_resume());
@@ -762,13 +762,13 @@ TEST(BufferedChannelTest, BufferedChannelTest_push_await_order)
     auto pushAwaiter_4 = channel.PushWait(4);
     EXPECT_FALSE(pushAwaiter_4.await_ready());
 
-    auto hdl_4 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl_4 = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(pushAwaiter_4.await_suspend(hdl_4));
 
     auto pushAwaiter_5 = channel.PushWait(5);
     EXPECT_FALSE(pushAwaiter_5.await_ready());
 
-    auto hdl_5 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl_5 = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(pushAwaiter_5.await_suspend(hdl_5));
 
     auto popValue = [&](int32_t expected) {
@@ -799,13 +799,13 @@ TEST(BufferedChannelTest, BufferedChannelTest_push_await_order)
     auto pushAwaiter_9 = channel.PushWait(9);
     EXPECT_FALSE(pushAwaiter_9.await_ready());
 
-    auto hdl_9 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl_9 = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(pushAwaiter_9.await_suspend(hdl_9));
 
     auto pushAwaiter_10 = channel.PushWait(10);
     EXPECT_FALSE(pushAwaiter_10.await_ready());
 
-    auto hdl_10 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl_10 = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(pushAwaiter_10.await_suspend(hdl_10));
 
     popValue(6);
@@ -828,7 +828,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_push_await_2)
     auto    popAwaiter = channel.PopWait(val);
     EXPECT_FALSE(popAwaiter.await_ready());
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(popAwaiter.await_suspend(hdl));
 
     auto pushAwaiter = channel.PushWait(42);
@@ -846,7 +846,7 @@ TEST(BufferedChannelTest, BufferedChannelTest_emplace_await_2)
     auto    popAwaiter = channel.PopWait(val);
     EXPECT_FALSE(popAwaiter.await_ready());
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(popAwaiter.await_suspend(hdl));
 
     auto pushAwaiter = channel.PushWait(42);
@@ -864,21 +864,21 @@ TEST(BufferedChannelTest, BufferedChannelTest_WaitForListeners_simple)
     EXPECT_FALSE(listenersAwaiter.await_ready());
 
     bool called{false};
-    auto hdl = tinycoro::test::MakeCoroutineHdl([&called] { called = true; });
+    auto hdl = tinycoro::test::MakeCoroutineHdl([&called](auto) { called = true; });
     EXPECT_TRUE(listenersAwaiter.await_suspend(hdl));
 
     int32_t val;
     auto    popawaiter = channel.PopWait(val);
     EXPECT_FALSE(popawaiter.await_ready());
 
-    auto hdl2 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl2 = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(popawaiter.await_suspend(hdl2));
 
     int32_t val2;
     auto    popawaiter2 = channel.PopWait(val2);
     EXPECT_FALSE(popawaiter2.await_ready());
 
-    auto hdl3 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl3 = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(popawaiter2.await_suspend(hdl3));
 
     // listenersAwaiter is notified
@@ -896,14 +896,14 @@ TEST(BufferedChannelTest, BufferedChannelTest_push_before_WaitForListeners)
     auto    popawaiter = channel.PopWait(val);
     EXPECT_FALSE(popawaiter.await_ready());
 
-    auto hdl2 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl2 = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(popawaiter.await_suspend(hdl2));
 
     int32_t val2;
     auto    popawaiter2 = channel.PopWait(val2);
     EXPECT_FALSE(popawaiter2.await_ready());
 
-    auto hdl3 = tinycoro::test::MakeCoroutineHdl([] { });
+    auto hdl3 = tinycoro::test::MakeCoroutineHdl();
     EXPECT_TRUE(popawaiter2.await_suspend(hdl3));
 
     auto listenersAwaiter = channel.WaitForListeners(2);
@@ -1920,4 +1920,166 @@ TEST_P(BufferedChannelTest, BufferedChannelFunctionalTest_tryPush)
     };
 
     tinycoro::AllOf(scheduler, producer(), consumer());
+}
+
+struct BufferedChannelTimeoutTest : testing::TestWithParam<size_t>
+{
+    tinycoro::SoftClock clock;
+    tinycoro::Scheduler scheduler;
+};
+
+INSTANTIATE_TEST_SUITE_P(BufferedChannelTimeoutTest, BufferedChannelTimeoutTest, testing::Values(1, 10, 100, 1000, 10000));
+
+TEST_P(BufferedChannelTimeoutTest, BufferedChannelTimeoutTest_timeout_all_push_wait)
+{
+    auto count = GetParam();
+
+    tinycoro::BufferedChannel<int32_t> channel{1};
+
+    std::atomic<int32_t> done{0};
+    std::atomic<int32_t> pushSuccess{0};
+
+    auto task = [&]() -> tinycoro::TaskNIC<> {
+        auto opt = co_await tinycoro::TimeoutAwait{clock, channel.PushWait(42), 10ms};
+
+        if(opt.has_value())
+        {
+            pushSuccess++;
+        }
+
+        done++;
+    };
+
+    std::vector<decltype(task())> tasks;
+    tasks.reserve(count);
+    for(size_t i = 0; i < count; i++)
+    {
+        tasks.emplace_back(task());
+    }
+
+    tinycoro::AllOf(scheduler, std::move(tasks));
+
+    EXPECT_EQ(count, done);
+
+    // only the first awaiter can push...
+    EXPECT_EQ(pushSuccess, 1);
+}
+
+TEST_P(BufferedChannelTimeoutTest, BufferedChannelTimeoutTest_timeout_race_push_pop_wait)
+{
+    auto count = GetParam();
+
+    tinycoro::BufferedChannel<int32_t> channel{1};
+
+    std::atomic<int32_t> popDone{0};
+    std::atomic<int32_t> pushDone{0};
+
+    auto producer = [&]() -> tinycoro::TaskNIC<> {
+        for(size_t i = 0; i < count; ++i)
+        {
+            co_await tinycoro::TimeoutAwait{clock, channel.PushWait(42), 1ms};
+            pushDone++;
+        }
+    };
+
+    auto consumer = [&]() -> tinycoro::TaskNIC<> {
+        for(size_t i = 0; i < count; ++i)
+        {
+            int32_t val;
+            co_await tinycoro::TimeoutAwait{clock, channel.PopWait(val), 1ms};
+            popDone++;
+        }
+    };
+
+    tinycoro::AllOf(scheduler, consumer(), producer());
+
+    EXPECT_EQ(count, popDone);
+    EXPECT_EQ(count, pushDone);
+}
+
+TEST_P(BufferedChannelTimeoutTest, BufferedChannelTimeoutTest_timeout_race_listeners_wait)
+{
+    auto count = GetParam();
+
+    tinycoro::BufferedChannel<int32_t> channel{1};
+
+    std::atomic<int32_t> listenerDone{0};
+
+    std::atomic_flag flag;
+
+    auto listener = [&]() -> tinycoro::TaskNIC<> {
+        for(size_t i = 0; i < count; ++i)
+        {
+            co_await tinycoro::TimeoutAwait{clock, channel.WaitForListeners(1), 1ms};
+            listenerDone++;
+        }
+
+        flag.test_and_set();
+    };
+
+    auto consumer = [&]() -> tinycoro::TaskNIC<> {
+        while(flag.test() == false)
+        {
+            std::this_thread::sleep_for(40ms);
+            int32_t val;
+            co_await tinycoro::TimeoutAwait{clock, channel.PopWait(val), 1ms};
+        }
+    };
+
+    tinycoro::AllOf(scheduler, listener(), consumer());
+
+    EXPECT_EQ(count, listenerDone);
+}
+
+TEST_P(BufferedChannelTimeoutTest, BufferedChannelTimeoutTest_timeout_all_pop_wait)
+{
+    auto count = GetParam();
+
+    tinycoro::BufferedChannel<int32_t> channel{1};
+
+    std::atomic<int32_t> done{0};
+
+    auto task = [&]() -> tinycoro::TaskNIC<> {
+        int32_t val;
+        auto opt = co_await tinycoro::TimeoutAwait{clock, channel.PopWait(val), 10ms};
+        EXPECT_FALSE(opt.has_value());
+        done++;
+    };
+
+    std::vector<decltype(task())> tasks;
+    tasks.reserve(count);
+    for(size_t i=0; i < count; i++)
+    {
+        tasks.emplace_back(task());
+    }
+
+    tinycoro::AllOf(scheduler, std::move(tasks));
+
+    EXPECT_EQ(count, done);
+}
+
+TEST_P(BufferedChannelTimeoutTest, BufferedChannelTimeoutTest_timeout_all_listeners_wait)
+{
+    auto count = GetParam();
+
+    tinycoro::BufferedChannel<int32_t> channel{1};
+
+    std::atomic<int32_t> done{0};
+
+    auto task = [&]() -> tinycoro::TaskNIC<> {
+        auto opt = co_await tinycoro::TimeoutAwait{clock, channel.WaitForListeners(1), 10ms};
+        EXPECT_FALSE(opt.has_value());
+        done++;
+    };
+
+    std::vector<decltype(task())> tasks;
+    tasks.reserve(count);
+    for(size_t i=0; i < count; i++)
+    {
+        tasks.emplace_back(task());
+    }
+
+    tinycoro::AllOf(scheduler, std::move(tasks));
+
+    EXPECT_EQ(count, done);
 }

--- a/test/src/CallOnce_test.cpp
+++ b/test/src/CallOnce_test.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+
+#include "tinycoro/CallOnce.hpp"
+#include "tinycoro/tinycoro_all.h"
+
+TEST(CallOnceTest, CallOnceTest)
+{
+    int32_t count{};
+
+    std::atomic_flag flag;
+    auto res = tinycoro::detail::CallOnce(flag, std::memory_order::acq_rel, [&]{ ++count; });
+
+    EXPECT_TRUE(res);
+    EXPECT_EQ(count, 1);
+
+    auto res2 = tinycoro::detail::CallOnce(flag, std::memory_order::acq_rel, [&]{ ++count; });
+    EXPECT_FALSE(res2);
+    EXPECT_EQ(count, 1);
+}
+
+struct CallOnceTest : testing::TestWithParam<int32_t>
+{
+};
+
+INSTANTIATE_TEST_SUITE_P(CallOnceTest, CallOnceTest, testing::Values(1, 10, 100, 500));
+
+TEST_P(CallOnceTest, CallOnceTest_threads)
+{
+    auto count = GetParam();
+ 
+    int32_t desired{};
+    std::atomic_flag flag;
+
+    tinycoro::Scheduler scheduler;
+    tinycoro::Barrier barrier{8};
+
+    auto task = [&]()->tinycoro::Task<> {
+        
+        for(int32_t i = 0; i < count;)
+        {
+            tinycoro::detail::CallOnce(flag, std::memory_order::acq_rel, [&]{ ++desired; });
+            co_await barrier.ArriveAndWait();
+
+            EXPECT_EQ(desired, ++i);
+
+            flag.clear();
+
+            co_await barrier.ArriveAndWait();
+
+            EXPECT_FALSE(flag.test());
+
+            co_await barrier.ArriveAndWait();
+        }
+    };
+
+    tinycoro::AllOf(scheduler, task(), task(), task(), task(), task(), task(), task(), task());
+}

--- a/test/src/CancellableSuspend_test.cpp
+++ b/test/src/CancellableSuspend_test.cpp
@@ -9,7 +9,7 @@ TEST(CancellableSuspentTest, CancellableSuspentTest)
 {
     tinycoro::CancellableSuspend suspend{};
 
-    auto hdl = tinycoro::test::MakeCoroutineHdl([]{});
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
     
     suspend.await_suspend(hdl);
 

--- a/test/src/Cancellablle_test.cpp
+++ b/test/src/Cancellablle_test.cpp
@@ -13,6 +13,7 @@ struct CancellableAwaiter_Mock
 
     MOCK_METHOD(bool, Cancel, ());
     MOCK_METHOD(void, Notify, ());
+    MOCK_METHOD(void, NotifyToDestroy, ());
 };
 
 TEST(CancellableTest, CancellableTest_mock_await_ready)
@@ -28,13 +29,13 @@ TEST(CancellableTest, CancellableTest_mock_await_ready)
 TEST(CancellableTest, CancellableTest_mock_await_suspend)
 {
     CancellableAwaiter_Mock mock;
-    auto hdl = tinycoro::test::MakeCoroutineHdl([]{});
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
 
     auto stopSource = hdl.promise().StopSource();
 
     EXPECT_CALL(mock, await_suspend).Times(1).WillOnce(testing::Return(true));
     EXPECT_CALL(mock, Cancel).WillOnce(testing::Return(true));
-    EXPECT_CALL(mock, Notify).Times(1);
+    EXPECT_CALL(mock, NotifyToDestroy).Times(1);
 
     tinycoro::Cancellable cancellable{std::move(mock)};
     EXPECT_TRUE(cancellable.await_suspend(hdl));
@@ -45,7 +46,7 @@ TEST(CancellableTest, CancellableTest_mock_await_suspend)
 TEST(CancellableTest, CancellableTest_mock_await_suspend_false)
 {
     CancellableAwaiter_Mock mock;
-    auto hdl = tinycoro::test::MakeCoroutineHdl([]{});
+    auto hdl = tinycoro::test::MakeCoroutineHdl();
 
     auto stopSource = hdl.promise().StopSource();
 

--- a/test/src/Example_tests.cpp
+++ b/test/src/Example_tests.cpp
@@ -705,7 +705,7 @@ struct CustomAwaiter
             self->_userData++;
 
             // resume the coroutine (you need to make them exception safe)
-            self->_resumeTask();
+            self->_resumeTask(tinycoro::ENotifyPolicy::RESUME);
         };
 
         AsyncCallbackAPIvoid(cb, this);
@@ -715,7 +715,7 @@ struct CustomAwaiter
 
     int32_t _userData{41};
 
-    std::function<void()> _resumeTask;
+    tinycoro::PauseHandlerCallbackT _resumeTask;
 };
 
 TEST_F(ExampleTest, ExampleOwnAwaiter)

--- a/test/src/Semaphore_test.cpp
+++ b/test/src/Semaphore_test.cpp
@@ -31,7 +31,7 @@ struct SemaphoreAwaiterTest : public testing::Test
 
     void SetUp() override
     {
-        hdl.promise().pauseHandler.emplace([]() { /* resumer callback */ });
+        hdl.promise().pauseHandler.emplace([](auto) { /* resumer callback */ });
     }
 
     SemaphoreMock<value_type>                                          mock;
@@ -100,7 +100,7 @@ struct SemaphoreTest : public testing::TestWithParam<size_t>
 
     void SetUp() override
     {
-        hdl.promise().pauseHandler.emplace([]() { /* resumer callback */ });
+        hdl.promise().pauseHandler.emplace([](auto) { /* resumer callback */ });
     }
 
     corohandle_type hdl;

--- a/test/src/Task_test.cpp
+++ b/test/src/Task_test.cpp
@@ -17,8 +17,8 @@ TEST(TaskTest, TaskTest_void)
     task.Resume();
 
     EXPECT_EQ(task.ResumeState(), tinycoro::ETaskResumeState::DONE);
-    auto pauseResumeCallback = []{};
-    task.SetPauseHandler(pauseResumeCallback);
+    
+    task.SetPauseHandler([](auto){});
 
     EXPECT_NO_THROW(task.SetStopSource(std::stop_source{}));
 }
@@ -39,8 +39,7 @@ TEST(TaskTest, TaskTest_int)
 
     EXPECT_EQ(task.ResumeState(), tinycoro::ETaskResumeState::DONE);
 
-    auto pauseResumeCallback = []{};
-    task.SetPauseHandler(pauseResumeCallback);
+    task.SetPauseHandler([](auto){});
 
     EXPECT_NO_THROW(task.SetStopSource(std::stop_source{}));
 }
@@ -125,6 +124,5 @@ TEST(CoroTaskTest, CoroTaskTest)
 
     EXPECT_EQ(task.ResumeState(), tinycoro::ETaskResumeState::PAUSED);
 
-    auto pauseResumeCallback = []{};
-    task.SetPauseHandler(pauseResumeCallback);
+    task.SetPauseHandler([](auto){});
 }

--- a/test/src/TimeoutAwait_test.cpp
+++ b/test/src/TimeoutAwait_test.cpp
@@ -1,20 +1,81 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "tinycoro/tinycoro_all.h"
 
+template <typename ReturnT>
 struct TestAwaitable
 {
-    
+    MOCK_METHOD(bool, await_ready, ());
+    MOCK_METHOD(ReturnT, await_resume, ());
+
+    // always suspend the coroutine.
+    bool await_suspend(auto hdl)
+    {
+        event.Set(tinycoro::context::PauseTask(hdl));
+        return true;
+    }
+
+    MOCK_METHOD(void, Notify, ());
+    MOCK_METHOD(bool, Cancel, ());
+
+    tinycoro::detail::PauseCallbackEvent event;
 };
 
-
-template<typename AwaitableT, typename TimeT>
-void TimeoutAwaitTest(AwaitableT&& awaitable, TimeT time)
+template <typename T>
+struct TimeoutAwaitTest : public testing::Test
 {
-    tinycoro::SoftClock clock; 
+    using value_type = T;
+};
 
-    auto task = [&]()->tinycoro::InlineTask<> {
+using TimeoutAwaitTestTypes = testing::Types<void, void*, int32_t, std::thread, std::string, std::unique_ptr<int32_t>>;
 
+TYPED_TEST_SUITE(TimeoutAwaitTest, TimeoutAwaitTestTypes);
+
+void TimeoutAwaitTestReturnValue(auto& awaitable)
+{
+    tinycoro::SoftClock clock;
+
+    auto task = [&]<template <typename> class AwaiterT, typename T>(AwaiterT<T>& awaiter) -> tinycoro::InlineTask<> {
+        auto res = co_await tinycoro::TimeoutAwait{clock, std::move(awaiter), 1ms};
+        if constexpr (std::same_as<void, T>)
+        {
+            EXPECT_TRUE((std::same_as<std::optional<tinycoro::VoidType>, decltype(res)>));
+        }
+        else
+        {
+            EXPECT_TRUE((std::same_as<std::optional<T>, decltype(res)>));
+        }
+        EXPECT_FALSE(res); // no value
+    };
+
+    tinycoro::AllOfInline(task(awaitable));
+}
+
+TYPED_TEST(TimeoutAwaitTest, TimeoutAwaitTest_typed)
+{
+    using T = typename TestFixture::value_type;
+
+    tinycoro::SoftClock clock;
+    TestAwaitable<T> awaitable;
+
+    EXPECT_CALL(awaitable, await_ready).Times(1);
+
+    // return that we could cancel the awaitable
+    EXPECT_CALL(awaitable, Cancel).WillOnce(testing::Return(true));
+    EXPECT_CALL(awaitable, Notify).Times(1).WillOnce([&] { awaitable.event.Notify(); });
+
+    EXPECT_CALL(awaitable, await_resume).Times(0);
+
+    TimeoutAwaitTestReturnValue(awaitable);
+}
+
+template <typename AwaitableT, typename TimeT>
+void TimeoutAwaitRealTest(AwaitableT&& awaitable, TimeT time)
+{
+    tinycoro::SoftClock clock;
+
+    auto task = [&]() -> tinycoro::InlineTask<> {
         [[maybe_unused]] auto start = clock.Now();
 
         // This is now cancellable with a timeout
@@ -40,100 +101,100 @@ TEST(TimeoutAwaitTest, TimeoutAwaitTest_ManualEvent)
 {
     tinycoro::ManualEvent event{};
 
-    TimeoutAwaitTest(event.Wait(), 100ms);
-    TimeoutAwaitTest(event.Wait(), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(event.Wait(), 100ms);
+    TimeoutAwaitRealTest(event.Wait(), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_AutoEvent)
 {
-    TimeoutAwaitTest(tinycoro::AutoEvent{}.Wait(), 100ms);
-    TimeoutAwaitTest(tinycoro::AutoEvent{}.Wait(), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(tinycoro::AutoEvent{}.Wait(), 100ms);
+    TimeoutAwaitRealTest(tinycoro::AutoEvent{}.Wait(), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_SingleEvent)
 {
-    TimeoutAwaitTest(tinycoro::SingleEvent<int32_t>{}.Wait(), 100ms);
-    TimeoutAwaitTest(tinycoro::SingleEvent<int32_t>{}.Wait(), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(tinycoro::SingleEvent<int32_t>{}.Wait(), 100ms);
+    TimeoutAwaitRealTest(tinycoro::SingleEvent<int32_t>{}.Wait(), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_Barrier)
 {
-    TimeoutAwaitTest(tinycoro::Barrier{3}.Wait(), 100ms);
-    TimeoutAwaitTest(tinycoro::Barrier{3}.Wait(), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(tinycoro::Barrier{3}.Wait(), 100ms);
+    TimeoutAwaitRealTest(tinycoro::Barrier{3}.Wait(), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_Latch)
 {
-    TimeoutAwaitTest(tinycoro::Latch{3}.Wait(), 100ms);
-    TimeoutAwaitTest(tinycoro::Latch{3}.Wait(), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(tinycoro::Latch{3}.Wait(), 100ms);
+    TimeoutAwaitRealTest(tinycoro::Latch{3}.Wait(), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_BufferedChannel_pop_wait)
 {
     tinycoro::BufferedChannel<int32_t> channel;
-    int32_t val{};
+    int32_t                            val{};
 
-    TimeoutAwaitTest(channel.PopWait(val), 100ms);
-    TimeoutAwaitTest(channel.PopWait(val), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(channel.PopWait(val), 100ms);
+    TimeoutAwaitRealTest(channel.PopWait(val), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_BufferedChannel_push_wait)
 {
     tinycoro::BufferedChannel<int32_t> channel{2};
-    int32_t val{};
+    int32_t                            val{};
 
     channel.Push(41);
     channel.Push(42);
 
     EXPECT_FALSE(channel.Empty());
 
-    TimeoutAwaitTest(channel.PushWait(val), 100ms);
-    TimeoutAwaitTest(channel.PushWait(val), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(channel.PushWait(val), 100ms);
+    TimeoutAwaitRealTest(channel.PushWait(val), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_BufferedChannel_push_and_close_wait)
 {
     tinycoro::BufferedChannel<int32_t> channel{2};
-    int32_t val{};
+    int32_t                            val{};
 
     channel.Push(41);
     channel.Push(42);
 
     EXPECT_FALSE(channel.Empty());
 
-    TimeoutAwaitTest(channel.PushAndCloseWait(val), 100ms);
-    TimeoutAwaitTest(channel.PushAndCloseWait(val), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(channel.PushAndCloseWait(val), 100ms);
+    TimeoutAwaitRealTest(channel.PushAndCloseWait(val), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_BufferedChannel_wait_for_listeners)
 {
     tinycoro::BufferedChannel<int32_t> channel{2};
 
-    TimeoutAwaitTest(channel.WaitForListeners(1), 100ms);
-    TimeoutAwaitTest(channel.WaitForListeners(1), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(channel.WaitForListeners(1), 100ms);
+    TimeoutAwaitRealTest(channel.WaitForListeners(1), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_UnbufferedChannel_pop_wait)
 {
     tinycoro::UnbufferedChannel<int32_t> channel;
-    int32_t val{};
+    int32_t                              val{};
 
-    TimeoutAwaitTest(channel.PopWait(val), 100ms);
-    TimeoutAwaitTest(channel.PopWait(val), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(channel.PopWait(val), 100ms);
+    TimeoutAwaitRealTest(channel.PopWait(val), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_UnbufferedChannel_push_wait)
 {
     tinycoro::UnbufferedChannel<int32_t> channel;
 
-    TimeoutAwaitTest(channel.PushWait(42), 100ms);
-    TimeoutAwaitTest(channel.PushWait(43), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(channel.PushWait(42), 100ms);
+    TimeoutAwaitRealTest(channel.PushWait(43), tinycoro::SoftClock::Now() + 100ms);
 }
 
 TEST(TimeoutAwaitTest, TimeoutAwaitTest_UnbufferedChannel_push_and_close_wait)
 {
     tinycoro::UnbufferedChannel<int32_t> channel;
 
-    TimeoutAwaitTest(channel.PushAndCloseWait(42), 100ms);
-    TimeoutAwaitTest(channel.PushAndCloseWait(43), tinycoro::SoftClock::Now() + 100ms);
+    TimeoutAwaitRealTest(channel.PushAndCloseWait(42), 100ms);
+    TimeoutAwaitRealTest(channel.PushAndCloseWait(43), tinycoro::SoftClock::Now() + 100ms);
 }

--- a/test/src/TimeoutAwait_test.cpp
+++ b/test/src/TimeoutAwait_test.cpp
@@ -1,0 +1,139 @@
+#include <gtest/gtest.h>
+
+#include "tinycoro/tinycoro_all.h"
+
+struct TestAwaitable
+{
+    
+};
+
+
+template<typename AwaitableT, typename TimeT>
+void TimeoutAwaitTest(AwaitableT&& awaitable, TimeT time)
+{
+    tinycoro::SoftClock clock; 
+
+    auto task = [&]()->tinycoro::InlineTask<> {
+
+        [[maybe_unused]] auto start = clock.Now();
+
+        // This is now cancellable with a timeout
+        auto res = co_await tinycoro::TimeoutAwait{clock, std::move(awaitable), time};
+
+        EXPECT_FALSE(res.has_value());
+
+        if constexpr (tinycoro::concepts::IsDuration<TimeT>)
+        {
+            // at least x time is elapsed
+            EXPECT_TRUE(start + 100ms <= clock.Now());
+        }
+        else
+        {
+            EXPECT_GE(clock.Now(), time);
+        }
+    };
+
+    tinycoro::AllOfInline(task());
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_ManualEvent)
+{
+    tinycoro::ManualEvent event{};
+
+    TimeoutAwaitTest(event.Wait(), 100ms);
+    TimeoutAwaitTest(event.Wait(), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_AutoEvent)
+{
+    TimeoutAwaitTest(tinycoro::AutoEvent{}.Wait(), 100ms);
+    TimeoutAwaitTest(tinycoro::AutoEvent{}.Wait(), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_SingleEvent)
+{
+    TimeoutAwaitTest(tinycoro::SingleEvent<int32_t>{}.Wait(), 100ms);
+    TimeoutAwaitTest(tinycoro::SingleEvent<int32_t>{}.Wait(), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_Barrier)
+{
+    TimeoutAwaitTest(tinycoro::Barrier{3}.Wait(), 100ms);
+    TimeoutAwaitTest(tinycoro::Barrier{3}.Wait(), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_Latch)
+{
+    TimeoutAwaitTest(tinycoro::Latch{3}.Wait(), 100ms);
+    TimeoutAwaitTest(tinycoro::Latch{3}.Wait(), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_BufferedChannel_pop_wait)
+{
+    tinycoro::BufferedChannel<int32_t> channel;
+    int32_t val{};
+
+    TimeoutAwaitTest(channel.PopWait(val), 100ms);
+    TimeoutAwaitTest(channel.PopWait(val), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_BufferedChannel_push_wait)
+{
+    tinycoro::BufferedChannel<int32_t> channel{2};
+    int32_t val{};
+
+    channel.Push(41);
+    channel.Push(42);
+
+    EXPECT_FALSE(channel.Empty());
+
+    TimeoutAwaitTest(channel.PushWait(val), 100ms);
+    TimeoutAwaitTest(channel.PushWait(val), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_BufferedChannel_push_and_close_wait)
+{
+    tinycoro::BufferedChannel<int32_t> channel{2};
+    int32_t val{};
+
+    channel.Push(41);
+    channel.Push(42);
+
+    EXPECT_FALSE(channel.Empty());
+
+    TimeoutAwaitTest(channel.PushAndCloseWait(val), 100ms);
+    TimeoutAwaitTest(channel.PushAndCloseWait(val), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_BufferedChannel_wait_for_listeners)
+{
+    tinycoro::BufferedChannel<int32_t> channel{2};
+
+    TimeoutAwaitTest(channel.WaitForListeners(1), 100ms);
+    TimeoutAwaitTest(channel.WaitForListeners(1), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_UnbufferedChannel_pop_wait)
+{
+    tinycoro::UnbufferedChannel<int32_t> channel;
+    int32_t val{};
+
+    TimeoutAwaitTest(channel.PopWait(val), 100ms);
+    TimeoutAwaitTest(channel.PopWait(val), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_UnbufferedChannel_push_wait)
+{
+    tinycoro::UnbufferedChannel<int32_t> channel;
+
+    TimeoutAwaitTest(channel.PushWait(42), 100ms);
+    TimeoutAwaitTest(channel.PushWait(43), tinycoro::SoftClock::Now() + 100ms);
+}
+
+TEST(TimeoutAwaitTest, TimeoutAwaitTest_UnbufferedChannel_push_and_close_wait)
+{
+    tinycoro::UnbufferedChannel<int32_t> channel;
+
+    TimeoutAwaitTest(channel.PushAndCloseWait(42), 100ms);
+    TimeoutAwaitTest(channel.PushAndCloseWait(43), tinycoro::SoftClock::Now() + 100ms);
+}

--- a/test/src/WaitInline_test.cpp
+++ b/test/src/WaitInline_test.cpp
@@ -191,7 +191,7 @@ TEST(WaitInlineTest, WaitInlineTest_pause)
 
     EXPECT_CALL(mock, await_resume()).Times(1).WillOnce(testing::Return(42));
 
-    auto resumer = [&]()->tinycoro::Task<void> { mock.pauseHandlerMock->cb(); co_return;};
+    auto resumer = [&]()->tinycoro::Task<void> { mock.pauseHandlerMock->cb(tinycoro::ENotifyPolicy::RESUME); co_return;};
 
     auto [val, voidValue] = tinycoro::AllOfInline(mock, resumer());
     EXPECT_EQ(42, val);
@@ -388,7 +388,7 @@ TEST(WaitInlineTest, WaitInline_FunctionalTest_1)
     };
 
     // set the value
-    event.SetValue(42);
+    event.Set(42);
 
     auto value = tinycoro::AllOfInline(consumer());
     EXPECT_EQ(value, 42);
@@ -407,7 +407,7 @@ TEST(WaitInlineTest, WaitInline_FunctionalTest_2)
     auto producer = [&event, &clock]()->tinycoro::Task<>
     {
         co_await tinycoro::SleepFor(clock, 100ms);
-        event.SetValue(42);
+        event.Set(42);
     };
 
     tinycoro::Scheduler scheduler{1};

--- a/test/src/mock/CoroutineHandleMock.h
+++ b/test/src/mock/CoroutineHandleMock.h
@@ -34,7 +34,7 @@ namespace tinycoro { namespace test {
     };
 
     template<typename T = void, typename InitialCancellablePolicyT = tinycoro::noninitial_cancellable_t>
-    auto MakeCoroutineHdl(std::regular_invocable auto pauseResumerCallback)
+    auto MakeCoroutineHdl(std::regular_invocable<tinycoro::ENotifyPolicy> auto pauseResumerCallback)
     {
         tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<T>> hdl;
         hdl.promise().pauseHandler.emplace(pauseResumerCallback, InitialCancellablePolicyT::value);
@@ -45,7 +45,7 @@ namespace tinycoro { namespace test {
     auto MakeCoroutineHdl()
     {
         tinycoro::test::CoroutineHandleMock<tinycoro::detail::Promise<T>> hdl;
-        hdl.promise().pauseHandler.emplace([]{}, InitialCancellablePolicyT::value);
+        hdl.promise().pauseHandler.emplace([]([[maybe_unused]] auto policy){}, InitialCancellablePolicyT::value);
         return hdl;
     }
 


### PR DESCRIPTION
Summary:
This PR introduces the TimeoutAwait wrapper, enabling coroutine suspension with a built-in timeout.
It supports both relative durations and absolute time points, allowing flexible integration with existing awaitables.

Details:
New awaiter wrapper: TimeoutAwait{clock, awaitable, timeout}
Works with any awaitable and a tinycoro::SoftClock instance.

timeout can be:
A relative duration (e.g. 10ms)
An absolute time point

Cancels the await operation when the timeout elapses, resuming the coroutine.
Fully integrates with the scheduler and existing synchronization primitives (e.g. Barrier, Event).

Motivation
Before this change, adding timeout behavior to an awaitable required custom boilerplate and manual clock handling.
TimeoutAwait makes time-constrained waiting a first-class feature, improving readability and reducing duplication.