### PR TITLE
add swap to copy and move assign

### DIFF
--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -23,22 +23,13 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install Clang 16, CMake
+    - name: Install Clang 16 and CMake
       run: |
-           apt-get update -y
-           apt update -y
-           apt-get upgrade -y
-           apt install -y wget lsb-release software-properties-common
-           wget https://apt.llvm.org/llvm-snapshot.gpg.key
-           apt-key add llvm-snapshot.gpg.key
-           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg
-           echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-16 main" | tee /etc/apt/sources.list.d/llvm.list
-           apt update -y
-           apt install -y python3
-           ln -sf /usr/bin/python3 /usr/bin/python  # Create a symlink for python
-           apt install -y clang-16 lld-16 cmake
-           update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
-           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
+        apt-get update -y
+        apt-get install -y python3 cmake clang-16 lld-16 wget lsb-release
+        ln -sf /usr/bin/python3 /usr/bin/python
+        update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
+        update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
 
     - name: Verify python version
       run: python --version

--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -8,68 +8,43 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest  # Or any supported runner, used to set up the container environment
-    container:
-      image: debian:latest  # The container image to use
+    runs-on: ubuntu-latest
 
     steps:
-    - name: Install Git
-      run: apt update && apt install -y git
-
-    - name: Verify Git Installation
-      run: git --version
-      
     - uses: actions/checkout@v4
       with:
         submodules: recursive
 
-    - name: Install Clang 16, CMake
+    - name: Install dependencies
       run: |
-          apt-get update -y
-          apt-get install -y clang lld cmake python3
-          ln -sf /usr/bin/python3 /usr/bin/python
-          update-alternatives --install /usr/bin/clang clang /usr/bin/clang 100 --force
-          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++ 100 --force
+        sudo apt update
+        sudo apt install -y clang-16 lld cmake python3 python3-pip
+        sudo ln -sf /usr/bin/python3 /usr/bin/python
 
-    - name: Verify python version
-      run: python --version
-
-    - name: Add safe repo directory
+    - name: Verify installations
       run: |
-           git init
-           git config --global --add safe.directory /__w/tinycoro/tinycoro
+        clang --version
+        python --version
 
-    - name: Initialize Git submodules
-      run: git submodule update --init --recursive
-      working-directory: ${{ github.workspace }}
-
-    - name: Debug Git Config
-      run: cat .git/config
-      working-directory: ${{ github.workspace }}
-
-    - name: Debug Submodules
-      run: git submodule status
-      working-directory: ${{ github.workspace }}
-
-    - name: Configure with coverage flags using Clang
-      run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -D CMAKE_CXX_COMPILER=clang++-16 -D CMAKE_C_COMPILER=clang-16 -D WithASAN=ON -D BUILD_WITH_DIAGNOSTICS=ON
-      working-directory: ${{ github.workspace }}
+    - name: Configure project with Clang and ASAN
+      run: cmake -B build \
+        -D CMAKE_BUILD_TYPE=Debug \
+        -D CMAKE_CXX_COMPILER=clang++-16 \
+        -D CMAKE_C_COMPILER=clang-16 \
+        -D WithASAN=ON \
+        -D BUILD_WITH_DIAGNOSTICS=ON
 
     - name: Build
       run: cmake --build build
-      working-directory: ${{ github.workspace }}
 
     - name: Run Unit Tests
       run: ./build/test/tinycoro_tests
-      working-directory: ${{ github.workspace }}
 
     - name: Run Examples
       run: ./build/tinycoro_example
-      working-directory: ${{ github.workspace }}
 
-    - name: Run echo server and stress test
+    - name: Run Echo Server and Stress Test
       run: |
         ./build/example/echo_server_example/tinycoro_echo_server &
         python ./example/echo_server_example/echo_server_stress_test.py 1000 true &
         wait
-      working-directory: ${{ github.workspace }}

--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -25,20 +25,18 @@ jobs:
 
     - name: Install Clang 16, CMake
       run: |
-           apt-get update -y
-           apt update -y
-           apt-get upgrade -y
-           apt install -y wget lsb-release
-           wget https://apt.llvm.org/llvm-snapshot.gpg.key
-           apt-key add llvm-snapshot.gpg.key
-           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg
-           echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-16 main" | tee /etc/apt/sources.list.d/llvm.list
-           apt update -y
-           apt install -y python3
-           ln -sf /usr/bin/python3 /usr/bin/python  # Create a symlink for python
-           apt install -y clang-16 lld-16 cmake
-           update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
-           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
+          apt-get update -y
+          apt-get install -y wget lsb-release gnupg python3 cmake
+          ln -sf /usr/bin/python3 /usr/bin/python  # Create a symlink for python
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg
+          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/trixie/ llvm-toolchain-trixie-16 main" \ 
+          | tee /etc/apt/sources.list.d/llvm.list
+
+          apt-get update -y
+          apt-get install -y clang-16 lld-16
+          
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
 
     - name: Verify python version
       run: python --version

--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -23,13 +23,22 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install Clang 16 and CMake
+    - name: Install Clang 16, CMake
       run: |
-        apt-get update -y
-        apt-get install -y python3 cmake clang-16 lld-16 wget lsb-release
-        ln -sf /usr/bin/python3 /usr/bin/python
-        update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
-        update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
+           apt-get update -y
+           apt update -y
+           apt-get upgrade -y
+           apt install -y wget lsb-release
+           wget https://apt.llvm.org/llvm-snapshot.gpg.key
+           apt-key add llvm-snapshot.gpg.key
+           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg
+           echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-16 main" | tee /etc/apt/sources.list.d/llvm.list
+           apt update -y
+           apt install -y python3
+           ln -sf /usr/bin/python3 /usr/bin/python  # Create a symlink for python
+           apt install -y clang-16 lld-16 cmake
+           update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
+           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
 
     - name: Verify python version
       run: python --version

--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -28,13 +28,21 @@ jobs:
           apt-get update -y
           apt-get install -y wget lsb-release gnupg python3 cmake
           ln -sf /usr/bin/python3 /usr/bin/python  # Create a symlink for python
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/trixie/ llvm-toolchain-trixie-16 main" \ 
-          | tee /etc/apt/sources.list.d/llvm.list
-
+            
+          # Download the LLVM key and save as .gpg
+          wget https://apt.llvm.org/llvm-snapshot.gpg.key -O llvm-snapshot.gpg.key
+          gpg --dearmor llvm-snapshot.gpg.key
+          mv llvm-snapshot.gpg /usr/share/keyrings/llvm-snapshot.gpg
+            
+          # Add LLVM 16 repo for Debian Trixie
+          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/trixie/ llvm-toolchain-trixie-16 main" \
+            | tee /etc/apt/sources.list.d/llvm.list
+            
+          # Update and install Clang 16 + LLD
           apt-get update -y
           apt-get install -y clang-16 lld-16
-          
+            
+          # Set alternatives for clang/clang++
           update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
 

--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -25,6 +25,7 @@ jobs:
 
     - name: Install Clang 16, CMake
       run: |
+           apt-get update -y
            apt update -y
            apt-get upgrade -y
            apt install -y wget lsb-release software-properties-common

--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -32,7 +32,7 @@ jobs:
           # Download the LLVM key and save as .gpg
           wget https://apt.llvm.org/llvm-snapshot.gpg.key -O llvm-snapshot.gpg.key
           gpg --dearmor llvm-snapshot.gpg.key
-          mv llvm-snapshot.gpg /usr/share/keyrings/llvm-snapshot.gpg
+          mv llvm-snapshot.gpg.key.gpg /usr/share/keyrings/llvm-snapshot.gpg
             
           # Add LLVM 16 repo for Debian Trixie
           echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/trixie/ llvm-toolchain-trixie-16 main" \

--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -28,8 +28,8 @@ jobs:
           apt-get update -y
           apt-get install -y clang lld cmake python3
           ln -sf /usr/bin/python3 /usr/bin/python
-          update-alternatives --install /usr/bin/clang clang /usr/bin/clang 100
-          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++ 100
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang 100 --force
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++ 100 --force
 
     - name: Verify python version
       run: python --version

--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -26,25 +26,10 @@ jobs:
     - name: Install Clang 16, CMake
       run: |
           apt-get update -y
-          apt-get install -y wget lsb-release gnupg python3 cmake
-          ln -sf /usr/bin/python3 /usr/bin/python  # Create a symlink for python
-            
-          # Download the LLVM key and save as .gpg
-          wget https://apt.llvm.org/llvm-snapshot.gpg.key -O llvm-snapshot.gpg.key
-          gpg --dearmor llvm-snapshot.gpg.key
-          mv llvm-snapshot.gpg.key.gpg /usr/share/keyrings/llvm-snapshot.gpg
-            
-          # Add LLVM 16 repo for Debian Trixie
-          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/trixie/ llvm-toolchain-trixie-16 main" \
-            | tee /etc/apt/sources.list.d/llvm.list
-            
-          # Update and install Clang 16 + LLD
-          apt-get update -y
-          apt-get install -y clang-16 lld-16
-            
-          # Set alternatives for clang/clang++
-          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
-          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
+          apt-get install -y clang lld cmake python3
+          ln -sf /usr/bin/python3 /usr/bin/python
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang 100
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++ 100
 
     - name: Verify python version
       run: python --version

--- a/include/tinycoro/Generator.hpp
+++ b/include/tinycoro/Generator.hpp
@@ -8,6 +8,7 @@
 
 #include <coroutine>
 #include <type_traits>
+#include <utility>
 
 namespace tinycoro {
     
@@ -105,11 +106,7 @@ namespace tinycoro {
 
             GeneratorT& operator=(GeneratorT&& other) noexcept
             {
-                if (std::addressof(other) != this)
-                {
-                    destroy();
-                    _hdl = std::exchange(other._hdl, nullptr);
-                }
+                GeneratorT{std::move(other)}.swap(*this);
                 return *this;
             }
 
@@ -118,6 +115,11 @@ namespace tinycoro {
             [[nodiscard]] auto begin() const { return GeneratorIterator<PromiseT>{_hdl}; }
 
             [[nodiscard]] auto end() const { return typename GeneratorIterator<PromiseT>::Sentinel{}; }
+
+            void swap(GeneratorT& other) noexcept
+            {
+                std::swap(_hdl, other.hdl);
+            } 
 
         private:
             void destroy()
@@ -129,7 +131,7 @@ namespace tinycoro {
                 }
             }
 
-            CoroHandleType _hdl;
+            CoroHandleType _hdl{nullptr};
         };
     } // namespace detail
 

--- a/include/tinycoro/Generator.hpp
+++ b/include/tinycoro/Generator.hpp
@@ -118,7 +118,7 @@ namespace tinycoro {
 
             void swap(GeneratorT& other) noexcept
             {
-                std::swap(_hdl, other.hdl);
+                std::swap(_hdl, other._hdl);
             } 
 
         private:

--- a/include/tinycoro/ReleaseGuard.hpp
+++ b/include/tinycoro/ReleaseGuard.hpp
@@ -27,8 +27,8 @@ namespace tinycoro {
 
         ReleaseGuard& operator=(ReleaseGuard&& other) noexcept
         {
-            unlock();
-            _device = std::exchange(other._device, nullptr);
+            ReleaseGuard{std::move(other)}.swap(*this);
+            return *this;
         }
 
         [[nodiscard]] bool owns_lock() const noexcept {
@@ -47,6 +47,11 @@ namespace tinycoro {
         ~ReleaseGuard()
         {
             unlock();
+        }
+
+        void swap(ReleaseGuard& other) noexcept
+        {
+            std::swap(other._device, _device);
         }
 
     private:

--- a/include/tinycoro/SchedulableTask.hpp
+++ b/include/tinycoro/SchedulableTask.hpp
@@ -8,6 +8,7 @@
 
 #include <stop_token>
 #include <cassert>
+#include <utility>
 
 #include "TaskResumer.hpp"
 #include "Promise.hpp"
@@ -47,11 +48,7 @@ namespace tinycoro { namespace detail {
 
         SchedulableTaskT& operator=(SchedulableTaskT&& other) noexcept
         {
-            if (std::addressof(other) != this)
-            {
-                Destroy();
-                _hdl = std::exchange(other._hdl, nullptr);
-            }
+            SchedulableTaskT{std::move(other)}.swap(*this);
             return *this;
         }
 
@@ -118,6 +115,11 @@ namespace tinycoro { namespace detail {
         }
 
         [[nodiscard]] auto& PauseState() noexcept { return _hdl.promise().pauseState; }
+
+        void swap(SchedulableTaskT& other) noexcept
+        {
+            std::swap(other._hdl, _hdl);
+        }
 
     private:
         void Destroy() noexcept

--- a/include/tinycoro/Task.hpp
+++ b/include/tinycoro/Task.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <cstddef>
 #include <stop_token>
+#include <utility>
 
 #include "Common.hpp"
 #include "Exception.hpp"
@@ -68,11 +69,7 @@ namespace tinycoro {
 
             CoroTask& operator=(CoroTask&& other) noexcept
             {
-                if (std::addressof(other) != this)
-                {
-                    destroy();
-                    _hdl = std::exchange(other._hdl, nullptr);
-                }
+                CoroTask{std::move(other)}.swap(*this);
                 return *this;
             }
 
@@ -122,6 +119,11 @@ namespace tinycoro {
             // Release the coroutine_handle object
             auto Release() noexcept { return std::exchange(_hdl, nullptr); }
 
+            void swap(CoroTask& other) noexcept
+            {
+                std::swap(other._hdl, _hdl);
+            }
+
         private:
             // Only used by MakeBound() to save
             // the coroutine function inside the
@@ -146,7 +148,7 @@ namespace tinycoro {
             [[no_unique_address]] CoroResumerT _coroResumer{};
 
             // The underlying coroutine_handle
-            coro_hdl_type _hdl;
+            coro_hdl_type _hdl{nullptr};
         };
 
     } // namespace detail


### PR DESCRIPTION
This PR refactors the move assignment operators across several core classes (GeneratorT, ReleaseGuard, SchedulableTaskT, SoftClockCancelToken, and CoroTask) to improve consistency, safety, and clarity.

Changes
- Replaced custom if (this != &other) + manual cleanup patterns with a uniform move-and-swap idiom.
- Added swap() implementations to each affected class to centralize the swapping logic.
- Ensured member handles/pointers are consistently default-initialized to nullptr.
- Simplified move assignment code paths while preserving strong exception safety.
- Cleaned up redundant destroy() / Destroy() calls in favor of clearer ownership transfer.

Benefits
- Improves maintainability and readability by unifying assignment logic.
- Prevents subtle self-assignment issues.
- Makes resource ownership and lifetime management more robust.
- Aligns implementations with modern C++ best practices (Rule of 5, move-and-swap idiom).