### PR TITLE
update and improve cmake for submodule usage

### DIFF
--- a/.github/workflows/asan_clang_16.yml
+++ b/.github/workflows/asan_clang_16.yml
@@ -39,8 +39,8 @@ jobs:
         -D CMAKE_BUILD_TYPE=Debug \
         -D CMAKE_CXX_COMPILER=clang++-16 \
         -D CMAKE_C_COMPILER=clang-16 \
-        -D WithASAN=ON \
-        -D BUILD_WITH_DIAGNOSTICS=ON
+        -D TINYCORO_WITH_ASAN=ON \
+        -D TINYCORO_BUILD_WITH_DIAGNOSTICS=ON
 
     - name: Build
       run: cmake --build build

--- a/.github/workflows/asan_gcc_13.yml
+++ b/.github/workflows/asan_gcc_13.yml
@@ -39,7 +39,7 @@ jobs:
       working-directory: ${{ github.workspace }}
     
     - name: Configure
-      run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -D WithASAN=ON -D BUILD_WITH_DIAGNOSTICS=ON
+      run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -D TINYCORO_WITH_ASAN=ON -D TINYCORO_BUILD_WITH_DIAGNOSTICS=ON
       working-directory: ${{ github.workspace }}
 
     - name: Build

--- a/.github/workflows/code_cov.yml
+++ b/.github/workflows/code_cov.yml
@@ -34,7 +34,7 @@ jobs:
       working-directory: ${{ github.workspace }}
     
     - name: Configure with coverage flags
-      run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -D CMAKE_CXX_FLAGS="--coverage" -D WithASAN=OFF -D BUILD_WITH_EXAMPLES=OFF
+      run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -D CMAKE_CXX_FLAGS="--coverage" -D TINYCORO_WITH_ASAN=OFF -D TINYCORO_BUILD_EXAMPLES=OFF
       working-directory: ${{ github.workspace }}
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ enable_testing()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+  set(TINYCORO_IS_TOP_LEVEL ON)
+else()
+  set(TINYCORO_IS_TOP_LEVEL OFF)
+endif()
+
 # Header-only, INTERFACE target for dependents
 add_library(tinycoro INTERFACE)
 add_library(tinycoro::tinycoro ALIAS tinycoro)
@@ -24,14 +30,14 @@ find_package(Threads REQUIRED)
 target_link_libraries(tinycoro INTERFACE Threads::Threads)
 
 # Option to enable ASAN
-option(WithASAN "Build with AddressSanitizer" OFF)
-option(WithTSAN "Build with ThreadSanitizer" OFF)
-option(BUILD_WITH_EXAMPLES "Build with Examples" ON)
-option(BUILD_WITH_DIAGNOSTICS "Build with diagnostics" OFF)
-option(TINYCORO_BUILD_TESTS "Build tinycoro unit tests" ON)
+option(TINYCORO_WITH_ASAN "Build with AddressSanitizer" OFF)
+option(TINYCORO_WITH_TSAN "Build with ThreadSanitizer" OFF)
+option(TINYCORO_BUILD_WITH_DIAGNOSTICS "Build with diagnostics" OFF)
+option(TINYCORO_BUILD_EXAMPLES "Build with Examples" ${TINYCORO_IS_TOP_LEVEL})
+option(TINYCORO_BUILD_TESTS "Build tinycoro unit tests" ${TINYCORO_IS_TOP_LEVEL})
 
-if (WithASAN AND WithTSAN)
-  message(FATAL_ERROR "WithASAN and WithTSAN cannot be enabled together")
+if (TINYCORO_WITH_ASAN AND TINYCORO_WITH_TSAN)
+  message(FATAL_ERROR "TINYCORO_WITH_ASAN and TINYCORO_WITH_TSAN cannot be enabled together")
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -61,7 +67,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 endif()
 
-if (WithASAN)
+if (TINYCORO_WITH_ASAN)
     message("Setting sanitizers...")
     add_compile_options(-fsanitize=address -fsanitize=undefined -fsanitize=leak)
     add_link_options(-fsanitize=address -fsanitize=undefined -fsanitize=leak)
@@ -69,7 +75,7 @@ if (WithASAN)
     set(ENV{LSAN_OPTIONS} "verbosity=2:log_threads=1")
 endif()
 
-if (WithTSAN)
+if (TINYCORO_WITH_TSAN)
   message("Setting ThreadSanitizer...")
   add_compile_options(-fsanitize=thread -fno-omit-frame-pointer -g -O0)
   add_link_options(-fsanitize=thread)
@@ -81,12 +87,12 @@ elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
   message("CMAKE_CXX_FLAGS_RELEASE -> ${CMAKE_CXX_FLAGS_RELEASE}")
 endif()
 
-if(BUILD_WITH_DIAGNOSTICS)
+if(TINYCORO_BUILD_WITH_DIAGNOSTICS)
   # add global flag for diagnostics
   add_compile_definitions(TINYCORO_DIAGNOSTICS)
 endif()
 
-if(BUILD_WITH_EXAMPLES)
+if(TINYCORO_BUILD_EXAMPLES)
 
 # Add an executable with the source file
 add_executable(${PROJECT_NAME} example/example.cpp)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to tinycoro
+
+Contributions to `tinycoro` are welcome and encouraged! If you'd like to contribute, please follow these steps:
+
+1. **Fork the repository**: Start by forking the project on GitHub and cloning your fork locally.
+2. **Create a branch**: Create a new branch for your feature or bugfix. Ensure the branch name reflects the purpose of your changes (e.g., `feature/new-feature` or `bugfix/issue-123`).
+3. **Make your changes**: Implement your feature or fix. Please ensure your code follows the project's style guidelines and includes appropriate tests.
+4. **Commit and push**: Commit your changes with clear, descriptive messages, and push your branch to your forked repository.
+5. **Open a pull request**: Submit a pull request (PR) to the main repository. Be sure to explain the purpose and impact of your changes in the PR description.
+
+Thank you for helping make `tinycoro` better.
+
+co_return ;)

--- a/README.md
+++ b/README.md
@@ -265,6 +265,15 @@ Simply copy the `include` folder into your C++20 (or greater) project. If necess
 #include <tinycoro/tinycoro_all.h>
 ```
 
+### Using tinycoro as a git submodule
+
+You can add `tinycoro` to your project as a git submodule and then use it from CMake by adding the subdirectory and linking the header-only target:
+
+```cmake
+add_subdirectory(pathTo/tinycoro)
+target_link_libraries(my_app PRIVATE tinycoro::tinycoro)
+```
+
 ## Examples
 The following examples demonstrate various use cases of the `tinycoro` library:
 

--- a/README.md
+++ b/README.md
@@ -2319,18 +2319,7 @@ In a coroutine-based environment, it is not recommended to use thread_local vari
 
 ## Contributing
 
-Contributions to `tinycoro` are welcome and encouraged! If you'd like to contribute, please follow these steps:
-
-1. **Fork the repository**: Start by forking the project on GitHub and cloning your fork locally.
-2. **Create a branch**: Create a new branch for your feature or bugfix. Ensure the branch name reflects the purpose of your changes (e.g., `feature/new-feature` or `bugfix/issue-123`).
-3. **Make your changes**: Implement your feature or fix. Please ensure your code follows the project's style guidelines and includes appropriate tests.
-4. **Commit and push**: Commit your changes with clear, descriptive messages, and push your branch to your forked repository.
-5. **Open a pull request**: Submit a pull request (PR) to the main repository. Be sure to explain the purpose and impact of your changes in the PR description.
-
-### Code Style and Guidelines
-- Follow the project's existing code structure and style.
-- Ensure all code is properly documented, especially new features or APIs.
-- Write tests to validate your changes and ensure they do not introduce regressions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for a short list of ways to help.
 
 ### Reporting Issues
 If you find a bug or have a feature request, please open an issue on the GitHub repository. Provide as much detail as possible, including steps to reproduce the issue, expected behavior, and any relevant system information.


### PR DESCRIPTION
Adds a short README section showing how to use tinycoro as a git submodule in a CMake project by adding it as a subdirectory and linking the header-only tinycoro::tinycoro target.

We check whether tinycoro is a top-level CMake project, and only in that case do we build the examples and tests.