### PR TITLE
Build fixes for gcc 16.1.1

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false   # prevents cancelling other matrix jobs
       matrix:
-        compiler: [GCC-11, GCC-12, GCC-13, GCC-14, GCC-15, Clang-16, Clang-17, Clang-18, Clang-19, Clang-20]
+        compiler: [GCC-11, GCC-12, GCC-13, GCC-14, GCC-15, GCC-16, Clang-16, Clang-17, Clang-18, Clang-19, Clang-20]
         build_type: [Debug, Release]
 
         include:
@@ -44,6 +44,10 @@ jobs:
             cxx: g++-15
             install: |
               brew install gcc@15 ninja
+          - compiler: GCC-16
+            cxx: g++-16
+            install: |
+              brew install gcc@16 ninja
           - compiler: Clang-16
             cxx: $(brew --prefix llvm@16)/bin/clang++
             install: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false   # prevents cancelling other matrix jobs
       matrix:
-        compiler: [GCC-11, GCC-12, GCC-13, GCC-14, GCC-15, GCC-16, Clang-16, Clang-17, Clang-18, Clang-19, Clang-20]
+        compiler: [GCC-11, GCC-12, GCC-13, GCC-14, GCC-15, Clang-16, Clang-17, Clang-18, Clang-19, Clang-20]
         build_type: [Debug, Release]
 
         include:
@@ -44,10 +44,6 @@ jobs:
             cxx: g++-15
             install: |
               brew install gcc@15 ninja
-          - compiler: GCC-16
-            cxx: g++-16
-            install: |
-              brew install gcc@16 ninja
           - compiler: Clang-16
             cxx: $(brew --prefix llvm@16)/bin/clang++
             install: |

--- a/example/echo_server_example/echo_server_main.cpp
+++ b/example/echo_server_example/echo_server_main.cpp
@@ -5,6 +5,7 @@
 #include <sys/epoll.h>
 #include <netdb.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include <iostream>
 #include <vector>

--- a/include/tinycoro/CoWait.hpp
+++ b/include/tinycoro/CoWait.hpp
@@ -25,7 +25,7 @@ namespace tinycoro {
         // In our use case with `co_await`, this is essential because
         // we must notify the awaitable object once the coroutine
         // has completed execution and all associated `co_await` tasks are done.
-        template <typename AwaitableT>
+        template <concepts::IsPointer AwaitableT>
         struct AsyncAwaitOnFinishWrapper
         {
             template <typename PromiseT, typename FutureStateT>
@@ -94,6 +94,8 @@ namespace tinycoro {
 
             void await_suspend(auto hdl)
             {
+                using SelfT = std::remove_pointer_t<decltype(this)>;
+
                 // put tast on pause
                 this->_event.Set(context::PauseTask(hdl));
 
@@ -101,7 +103,7 @@ namespace tinycoro {
                 this->_futures = std::apply(
                     [this]<typename... Ts>(Ts&&... ts) {
                         (ts.SetCustomData(this), ...);
-                        return this->_scheduler.template Enqueue<tinycoro::unsafe::Promise, AsyncAwaitOnFinishWrapper<decltype(this)>>(
+                        return this->_scheduler.template Enqueue<tinycoro::unsafe::Promise, AsyncAwaitOnFinishWrapper<SelfT*>>(
                             std::forward<Ts>(ts)...);
                     },
                     std::move(this->_coroutineTasks));
@@ -159,6 +161,8 @@ namespace tinycoro {
 
             void await_suspend(auto hdl)
             {
+                using SelfT = std::remove_pointer_t<decltype(this)>;
+
                 // put tast on pause
                 this->_event.Set(context::PauseTask(hdl));
 
@@ -166,7 +170,7 @@ namespace tinycoro {
                 this->_futures = std::apply(
                     [this]<typename... Ts>(Ts&&... ts) {
                         ((ts.SetCustomData(this), ts.SetStopSource(_stopSource)), ...);
-                        return this->_scheduler.template Enqueue<tinycoro::unsafe::Promise, AsyncAwaitOnFinishWrapper<decltype(this)>>(
+                        return this->_scheduler.template Enqueue<tinycoro::unsafe::Promise, AsyncAwaitOnFinishWrapper<SelfT*>>(
                             std::forward<Ts>(ts)...);
                     },
                     std::move(this->_coroutineTasks));

--- a/include/tinycoro/Common.hpp
+++ b/include/tinycoro/Common.hpp
@@ -256,6 +256,9 @@ namespace tinycoro {
         template<typename... Args>
         concept IsTuple = detail::IsTupleT<Args...>::value;
 
+        template <typename T>
+        concept IsPointer = std::is_pointer<T>::value;
+
     } // namespace concepts
 
     namespace detail {


### PR DESCRIPTION
- Added missing include of `unistd.h`,
- added concept `IsPointer` for `AsyncAwaitOnFinishWrapper`,
- fixed deduction of `decltype(this)` as `AsyncAnyOfAwaiterT<...>*&` inside of lambdas which capture `this`, although `AsyncAnyOfAwaiterT<...>*` is needed
- (brew does not provide gcc 16 yet, will be added via another PR to github action when available)